### PR TITLE
Ardunio GitHub actions for Controller

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/compile-sketches@v1
-        fqbn: 'esp32:esp32:esp32da'
         with:
+          fqbn: 'esp32:esp32:esp32da'
           platforms: |
             - name: 'esp32:esp32'
               source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json

--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -8,9 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/compile-sketches@v1
+        fqbn: 'esp32:esp32:esp32da'
         with:
           platforms: |
-            - name: 'esp32:esp32:esp32da'
+            - name: 'esp32:esp32'
               source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
           sketch-paths: |
             - ./Controller

--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -1,0 +1,18 @@
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-sketch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/compile-sketches@v1
+        with:
+          platforms: |
+            - name: 'esp32:esp32:esp32da'
+              source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+          sketch-paths: |
+            - ./Controller
+          libraries: |
+            - name: Bounce2

--- a/Controller/Controller.ino
+++ b/Controller/Controller.ino
@@ -568,11 +568,11 @@ void loop()
 {      
 }
 
-//reads the serial line,  x,y,z,RX,RY,RZX, Where X is used to indicate end of line. 
+//reads the serial line: x,y,z,RX,RY,RZX, Where X is used to indicate end of line. 
 //else data will buffer and parsed once a full line is available.
 void processIncomingByte (const byte inByte)
 {
-    static char input_line [MAX_INPUT];
+    static char input_line [MAX_SERIAL_INPUT];
     static unsigned int input_pos = 0;
   
     switch (inByte)

--- a/Controller/helpers.h
+++ b/Controller/helpers.h
@@ -52,7 +52,7 @@ static float servoPulseMultiplierPerRadian =  800/(pi/4);
 #define ESTOP_RATE_LIMIT_TIME 3000
 
 // how much serial data we expect before a newline
-#define MAX_INPUT 60
+#define MAX_SERIAL_INPUT 60
    
 //used to hold current status of a motor
 struct acServo {


### PR DESCRIPTION
This pull request introduces automatic builds for the Ardunio Controller (found in `./Controller`) which helps spot mistakes earlier on. It runs on every `push` and `pull request` and takes about 1m30s to run, [example run here](https://github.com/HappyPaul55/6DOF-Rotary-Stewart-Motion-Simulator/runs/6335669962?check_suite_focus=true).