### PR TITLE
fix(ci): CMAKE_POLICY_VERSION_MINIMUM=3.5 so cJSON configures on CMake ≥4

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -4,6 +4,13 @@ project(stewart-platform LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Some fetched deps (e.g. cJSON v1.7.18) still declare cmake_minimum_required
+# < 3.5, which CMake >= 4.0 (the VS 2026 CI runner) rejects outright. Provide a
+# compatible policy floor so those subprojects still configure. This variable is
+# read by each subproject's cmake_minimum_required; it is silently ignored on
+# CMake < 3.31, so it is safe for older local toolchains too.
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 # ── Fetch dependencies ──────────────────────────────────────────────
 include(FetchContent)
 


### PR DESCRIPTION
## Problem
The `Build Desktop App (CMake)` CI job started failing at **Configure CMake**:

```
CMake Error at build/_deps/cjson-src/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

cJSON v1.7.18 (pulled via FetchContent) still declares a pre-3.5 `cmake_minimum_required`. The GitHub Windows runner picked up the CMake bundled with **Visual Studio 2026** (CMake ≥ 4.0), which **removed** compatibility with that old policy version — so configure aborts before any of our sources compile. Environmental; unrelated to recent code changes.

## Fix
Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` in `app/CMakeLists.txt` **before** `FetchContent`. Each fetched subproject reads it at its `cmake_minimum_required` and adopts a still-supported policy floor. The variable is silently ignored on CMake < 3.31, so older local toolchains are unaffected. **No functional change.**

## Verify
CI on this PR runs the exact runner that failed — a green `Build Desktop App (CMake)` confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)