### PR TITLE
WIP: Phase-1 HIL network bridge (Linux host: UDP↔COBS relay + WS/TCP control)

### DIFF
--- a/bridge/PROTOCOL.md
+++ b/bridge/PROTOCOL.md
@@ -44,7 +44,7 @@ COBS_encode( [channel_byte] + payload )  +  0x00 delimiter
 | `CH_LOG`    | `0x04` | ESP→App  | log / debug text |
 | `CH_RESP`   | `0x05` | ESP→App  | command response text |
 | `CH_DATA18` | `0x06` | App→ESP  | **BAKED** motion, 18 bytes = 6×uint24 LE (low 18 bits) |
-| `CH_DATA_RAW` | `0x07` | App→ESP | **RAW** motion telemetry, 6×int16 LE (pre-cueing) |
+| `CH_DATA_RAW` | `0x07` | App→ESP | **RAW** motion telemetry, 24 bytes = 6×float32 LE (pre-cueing) |
 
 Worked example (`CH_CMD` + `"AB"`): raw = `02 41 42` → COBS prepends one code
 byte `04` → `04 02 41 42` → + delimiter → **`04 02 41 42 00`**.
@@ -54,9 +54,12 @@ byte `04` → `04 02 41 42` → + delimiter → **`04 02 41 42 00`**.
 * **`CH_DATA18` (0x06, baked):** legacy path. The desktop app runs the motion-cue
   engine and ships post-cueing 6×uint24 servo-space values.
 * **`CH_DATA_RAW` (0x07, raw):** the **decided LIVE path**. The app ships **raw
-  (pre-cueing) telemetry** and the **ESP runs the single on-device cue engine**
-  (washout + tilt-coordination + axis scaling + intensity/gain, tunable via
-  NVS). One cue engine for DEMO and LIVE → identical feel, live-tunable feel.
+  (pre-cueing) telemetry** as **6×float32 LE = 24 bytes**, in **app axis order
+  (surge=0, sway=1)**; the **ESP runs the single on-device cue engine** (washout
+  + tilt-coordination + axis scaling + intensity/gain, tunable via NVS) **and
+  swaps axes after cueing**. One cue engine for DEMO and LIVE → identical,
+  live-tunable feel. This float32 layout matches the on-device demo store's
+  **.m6p v2 (`M6P2`)** format byte = float32.
 
 **The bridge does not cue and does not inspect motion payloads.** For both
 channels the app builds the complete COBS frame and the bridge forwards the UDP
@@ -107,10 +110,13 @@ channel byte the app puts in the frame.
 On connect the bridge first sends:
 
 ```json
-{ "type": "hello", "api_version": 1, "service": "hil-bridge", "transport": "ws|tcp" }
+{ "type": "hello", "api_version": 1, "service": "hil-bridge",
+  "transport": "ws|tcp", "auth_required": false }
 ```
 
-immediately followed by a `status` event snapshot.
+If `auth_required` is `false` (the default — auth disabled) this is immediately
+followed by a `status` event snapshot. If `true`, the client must first
+authenticate (see **Auth** below); the status snapshot is withheld until it does.
 
 ### Verbs
 
@@ -163,19 +169,20 @@ gate. Boot default = **OFF** (safe idle, motion gated).
 
 | Source | Bridge action | UDP gate |
 |--------|---------------|----------|
-| **OFF**  | send `PLAY:STOP` **+** `SOURCE:OFF` (fwd-compat) | **closed** (drop) |
+| **OFF**  | send `PLAY:STOP` **+** `ZERO` (home) **+** `SOURCE:OFF` (fwd-compat) | **closed** (drop) |
 | **DEMO** | send `SOURCE:DEMO` (fwd-compat) **+** `PLAY:START` | closed (drop) |
 | **LIVE** | send `SOURCE:LIVE` (fwd-compat) **+** `PLAY:STOP` | **open** (forward) |
+
+**OFF = HOME (locked round-2 decision):** OFF (and startup) must **HOME** the
+platform. No dedicated `SOURCE:`/`HOME` firmware command exists yet (Phase 3),
+but the existing **`ZERO`** command homes on today's firmware, so OFF sends
+`PLAY:STOP` then `ZERO`. When the Phase-3 `SOURCE:` selector lands (which will
+home internally), the explicit `ZERO` can be dropped.
 
 **Forward-compat note:** the firmware `SOURCE:` / `BOOT_SOURCE:` / `SELECT:`
 commands are **Phase 3** (HIL_BRIDGE.md). Today's firmware ignores unknown
 commands, so the bridge sends them now for a clean cutover; the operative
-commands today are `PLAY:*`.
-
-**OFF = STOP, not HOME (for now):** HIL_BRIDGE.md "Decisions round 2" wants OFF
-(and startup) to **HOME** the platform. No `HOME` command exists in the firmware
-yet (that lands with the Phase-3 SOURCE work), so the bridge currently issues
-`PLAY:STOP` only. See OPEN QUESTIONS in the delivery notes.
+commands today are `PLAY:*` and `ZERO`.
 
 ---
 
@@ -189,6 +196,26 @@ yet (that lands with the Phase-3 SOURCE work), so the bridge currently issues
 | Bind addr  | `--bind`     | `HIL_BIND`     | `0.0.0.0` |
 | Serial dev | `--serial-dev` | `HIL_SERIAL_DEV` | *(unset → MockSerial, no hardware)* |
 | Baud       | `--baud`     | `HIL_BAUD`     | `921600` |
+| Auth token | `--auth-token` | `HIL_AUTH_TOKEN` | *(unset → auth DISABLED)* |
 
-**Auth:** none on the LAN (parity with the app's `:8770` server). If the bridge
-is ever exposed beyond a trusted LAN, add a token — flagged in OPEN QUESTIONS.
+---
+
+## 6. Auth (disabled by default; seam is built)
+
+**Current state: DISABLED.** No auth on the LAN (parity with the app's `:8770`
+server). `hello.auth_required` is `false` and every verb is accepted.
+
+**The handshake seam is already implemented** so enabling it later needs no
+rewrite. When the bridge is started with a token (`--auth-token` /
+`HIL_AUTH_TOKEN`):
+
+* `hello.auth_required` is `true` and the `status` snapshot is withheld.
+* The client's **first message must be** `{"auth": "<token>"}`. On success the
+  bridge replies `{"type":"resp","verb":"auth","ok":true}` then sends the
+  `status` snapshot; the connection proceeds normally.
+* Any other message while un-authed is rejected with
+  `{"type":"resp","verb":"auth","ok":false,"error":"auth_required"}`.
+
+**TODO (Android / off-LAN phase):** turn this on for connections that leave the
+trusted LAN, and consider TLS/`wss://` termination in front of the bridge. Until
+then it stays disabled for desktop-app parity.

--- a/bridge/PROTOCOL.md
+++ b/bridge/PROTOCOL.md
@@ -1,0 +1,194 @@
+# HIL Bridge Protocol (DECIDED spec)
+
+The bridge is the Voron-side relay between the 6DOF app and the ESP32 "mini" HIL
+device. It exposes two planes:
+
+1. **Motion plane — UDP** (fire-and-forget, low latency): the live motion-cue
+   stream.
+2. **Control plane — JSON** over **two interchangeable transports**:
+   * **WebSocket** (`ws://<voron>:8788`) — for the Android control client and
+     anything WS-native.
+   * **line-JSON TCP** (`tcp://<voron>:8789`) — one JSON object per `\n`-
+     terminated line, so the desktop app reuses its existing winsock + cJSON
+     code (same style as the app's `:8770` control server).
+
+   Both control transports serve the **identical** verb / request / response /
+   event schema below. A client may use either. Set a port to `0` to disable
+   that transport.
+
+Everything downstream of the bridge (serial framing, firmware handlers) is
+unchanged from the direct-USB path — the bridge reuses the wire format verbatim.
+
+---
+
+## 1. COBS wire format (bridge ↔ mini, USB serial @921600)
+
+Ported byte-for-byte from `Controller/include/cobs.h` +
+`Controller/main/CobsTransport.cpp`. One frame on the wire is:
+
+```
+COBS_encode( [channel_byte] + payload )  +  0x00 delimiter
+```
+
+* The **channel byte is the first byte** of the pre-encode ("raw") frame.
+* COBS guarantees the encoded body contains no `0x00`, so a single `0x00`
+  delimits frames. The **caller appends** the delimiter (matches `cobs.h`:
+  `cobs_encode` returns length WITHOUT the trailing `0x00`).
+
+### Channels
+
+| Channel     | ID     | Dir      | Payload |
+|-------------|--------|----------|---------|
+| `CH_CMD`    | `0x02` | App→ESP  | ASCII command string |
+| `CH_TEL`    | `0x03` | ESP→App  | telemetry, 48 bytes = 12×float32 LE (angles[6]+positions[6]) |
+| `CH_LOG`    | `0x04` | ESP→App  | log / debug text |
+| `CH_RESP`   | `0x05` | ESP→App  | command response text |
+| `CH_DATA18` | `0x06` | App→ESP  | **BAKED** motion, 18 bytes = 6×uint24 LE (low 18 bits) |
+| `CH_DATA_RAW` | `0x07` | App→ESP | **RAW** motion telemetry, 6×int16 LE (pre-cueing) |
+
+Worked example (`CH_CMD` + `"AB"`): raw = `02 41 42` → COBS prepends one code
+byte `04` → `04 02 41 42` → + delimiter → **`04 02 41 42 00`**.
+
+### Baked (0x06) vs Raw (0x07) — the motion model
+
+* **`CH_DATA18` (0x06, baked):** legacy path. The desktop app runs the motion-cue
+  engine and ships post-cueing 6×uint24 servo-space values.
+* **`CH_DATA_RAW` (0x07, raw):** the **decided LIVE path**. The app ships **raw
+  (pre-cueing) telemetry** and the **ESP runs the single on-device cue engine**
+  (washout + tilt-coordination + axis scaling + intensity/gain, tunable via
+  NVS). One cue engine for DEMO and LIVE → identical feel, live-tunable feel.
+
+**The bridge does not cue and does not inspect motion payloads.** For both
+channels the app builds the complete COBS frame and the bridge forwards the UDP
+datagram **verbatim** to the UART. Raw-vs-baked is chosen entirely by which
+channel byte the app puts in the frame.
+
+---
+
+## 2. Motion plane — UDP datagrams
+
+* **Datagram body = one verbatim COBS motion frame** (`CH_DATA18` **or**
+  `CH_DATA_RAW`) — the exact bytes the app would have written to a direct serial
+  link, delimiter included. The bridge does **zero** re-encoding.
+* Default port **8767** (`--udp-port`).
+* **Gating:** the bridge forwards a datagram to the UART **only when the current
+  source is `LIVE`**. In `OFF`/`DEMO` datagrams are silently dropped (counted in
+  `udp.dropped`).
+* Fire-and-forget: no per-datagram ACK; loss is tolerated (next frame supersedes).
+
+---
+
+## 3. Control plane — JSON schema (WS + line-JSON TCP)
+
+`api_version` = **1**.
+
+### Request (client → bridge)
+
+```json
+{ "verb": "<verb>", "id": <optional any>, ...verb-specific fields }
+```
+
+`id`, if present, is echoed on the matching `resp` so a client can correlate.
+(`cmd` is accepted as an alias for `verb`.)
+
+### Response (bridge → requesting client only)
+
+```json
+{ "type": "resp", "verb": "<verb>", "ok": true|false,
+  "id": <echoed if sent>, "error": "<code>"?, ...result fields }
+```
+
+### Events (bridge → ALL connected clients, unsolicited)
+
+```json
+{ "type": "event", "event": "status|log|resp|telemetry", ... }
+```
+
+On connect the bridge first sends:
+
+```json
+{ "type": "hello", "api_version": 1, "service": "hil-bridge", "transport": "ws|tcp" }
+```
+
+immediately followed by a `status` event snapshot.
+
+### Verbs
+
+| Verb            | Fields | Effect / result |
+|-----------------|--------|-----------------|
+| `set_source`    | `source`: `OFF`\|`DEMO`\|`LIVE` | drive the state machine (below); result `{source, motion_gated}` |
+| `play`          | `action`: `start`\|`stop`\|`loop` | send `PLAY:START/STOP/LOOP`; result `{play_state}` |
+| `status`        | — | result = full status body; also re-broadcast as a `status` event |
+| `select_demo`   | `name` | select on-device demo (fwd-compat `SELECT:<name>`); result `{selected_demo}` |
+| `boot_source`   | `source` | persist boot default (fwd-compat `BOOT_SOURCE:<src>`); result `{boot_source}` |
+| `mem`           | — | query device used/free (`MEM?`); real numbers return later as a `resp` event (Phase 3 firmware) |
+| `list_files`    | — | query device file list (`LIST?`); entries return as `resp` events (Phase 3 firmware) |
+| `upload_file`   | `name`, `chunk_index`, `total_chunks`, `data`(b64) | **STUB** — accepts the chunked handshake shape; real erase+stream+CRC is Phase 3 |
+| `delete_file`   | `name` | **STUB** |
+| `flash_firmware`| (impl-defined) | **STUB** — esptool-over-USB is Phase 4 |
+
+### Status body
+
+```json
+{
+  "api_version": 1,
+  "source": "OFF|DEMO|LIVE",
+  "boot_source": "OFF|DEMO|LIVE",
+  "play_state": "stopped|playing|looping",
+  "selected_demo": "<name|null>",
+  "motion_gated": true,            // true unless source==LIVE
+  "serial_mock": true,             // true when running with no hardware
+  "serial_device": "<dev|null>",
+  "udp": { "rx": 0, "forwarded": 0, "dropped": 0 },
+  "clients": 1,
+  "uptime_s": 12.3
+}
+```
+
+### Event types
+
+* `status`   — the status body above, on every state change.
+* `log`      — `{channel:"LOG",  text}` from device `CH_LOG`.
+* `resp`     — `{channel:"RESP", text}` from device `CH_RESP` (command replies,
+  later `MEM?`/`LIST?` results).
+* `telemetry`— `{channel:"TEL", hex, len}` from device `CH_TEL` (48-byte blob as
+  hex; clients decode the 12×float32 LE as needed).
+
+---
+
+## 4. Source state machine (OFF / DEMO / LIVE)
+
+Single selector, owned by the control API; it is the sole authority for the UDP
+gate. Boot default = **OFF** (safe idle, motion gated).
+
+| Source | Bridge action | UDP gate |
+|--------|---------------|----------|
+| **OFF**  | send `PLAY:STOP` **+** `SOURCE:OFF` (fwd-compat) | **closed** (drop) |
+| **DEMO** | send `SOURCE:DEMO` (fwd-compat) **+** `PLAY:START` | closed (drop) |
+| **LIVE** | send `SOURCE:LIVE` (fwd-compat) **+** `PLAY:STOP` | **open** (forward) |
+
+**Forward-compat note:** the firmware `SOURCE:` / `BOOT_SOURCE:` / `SELECT:`
+commands are **Phase 3** (HIL_BRIDGE.md). Today's firmware ignores unknown
+commands, so the bridge sends them now for a clean cutover; the operative
+commands today are `PLAY:*`.
+
+**OFF = STOP, not HOME (for now):** HIL_BRIDGE.md "Decisions round 2" wants OFF
+(and startup) to **HOME** the platform. No `HOME` command exists in the firmware
+yet (that lands with the Phase-3 SOURCE work), so the bridge currently issues
+`PLAY:STOP` only. See OPEN QUESTIONS in the delivery notes.
+
+---
+
+## 5. Config / ports (defaults)
+
+| What | Flag | Env | Default |
+|------|------|-----|---------|
+| UDP motion | `--udp-port` | `HIL_UDP_PORT` | `8767` |
+| WS control | `--ws-port`  | `HIL_WS_PORT`  | `8788` |
+| TCP control (line-JSON) | `--tcp-port` | `HIL_TCP_PORT` | `8789` |
+| Bind addr  | `--bind`     | `HIL_BIND`     | `0.0.0.0` |
+| Serial dev | `--serial-dev` | `HIL_SERIAL_DEV` | *(unset → MockSerial, no hardware)* |
+| Baud       | `--baud`     | `HIL_BAUD`     | `921600` |
+
+**Auth:** none on the LAN (parity with the app's `:8770` server). If the bridge
+is ever exposed beyond a trusted LAN, add a token — flagged in OPEN QUESTIONS.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,71 @@
+# HIL Network Bridge (Voron-side relay)
+
+Phase-1 bridge service from `6dof/HIL_BRIDGE.md`. It relays the 6DOF app's
+network motion stream to the ESP32 "mini" over USB COBS, and exposes a control
+API for source modes / status / (stubbed) file + firmware ops.
+
+```
+ app --UDP (verbatim COBS motion frame)--> udp_relay --(LIVE only)--> UART --> mini
+ app --WS / line-JSON TCP (control)------> control_api --CH_CMD-----> UART --> mini
+ mini --CH_TEL/LOG/RESP------------------> serial_link --> control_api --> clients
+```
+
+See **`PROTOCOL.md`** for the decided wire format + JSON schema + state machine.
+
+## Modules
+
+| File | Role |
+|------|------|
+| `cobs.py`        | COBS codec + channel framing, byte-parity with `Controller/include/cobs.h` |
+| `serial_link.py` | async pyserial @921600 link; RX splits on `0x00`, routes TEL/LOG/RESP; **serial is optional/mockable** |
+| `udp_relay.py`   | asyncio UDP endpoint; forwards each datagram verbatim to the UART, **LIVE-gated** |
+| `control_api.py` | WebSocket **and** line-JSON TCP control server; OFF/DEMO/LIVE state machine; event fan-out |
+| `bridge.py`      | entrypoint; wires everything under one asyncio loop + graceful shutdown |
+| `hil_bridge.service`, `install.sh` | systemd unit + one-command installer (the "create service" action) |
+| `test_client.py` | local demo: WS commands + UDP motion frames |
+| `selftest.py`    | hardware-free self-test (COBS parity, UDP gating, WS + TCP control) |
+
+## Run locally (no hardware)
+
+With `HIL_SERIAL_DEV` unset the bridge uses a `MockSerial` sink — safe to run
+with no ESP attached (the physical mini may be in use elsewhere).
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt      # Windows: .venv\Scripts\pip
+.venv/bin/python selftest.py                   # expect: RESULT: ALL GREEN
+.venv/bin/python bridge.py                      # starts udp:8767 ws:8788 tcp:8789 (mock serial)
+# in another shell:
+.venv/bin/python test_client.py                 # drives WS + streams UDP motion
+```
+
+Point at real hardware by adding `--serial-dev /dev/ttyUSB0` (or a
+`/dev/serial/by-id/...` path). Add `--require-device` to fail instead of
+degrading to mock if the port can't open.
+
+## Install on the Voron (`knaufinator@192.168.1.168`)
+
+From a checkout of this repo on the Voron:
+
+```bash
+cd 6DOF-Rotary-Stewart-Motion-Simulator/bridge
+sudo ./install.sh                       # copies to /opt/hil-bridge, venv, deps,
+                                        # installs+enables+starts hil_bridge.service
+# with a known serial device:
+sudo SERIAL_DEV=/dev/serial/by-id/usb-...-if00 ./install.sh
+```
+
+Then:
+
+```bash
+journalctl -u hil_bridge.service -f     # logs
+systemctl restart hil_bridge.service    # after editing the unit's env
+```
+
+Ports (defaults): UDP motion `8767`, WS control `8788`, TCP control `8789`.
+`install.sh` starts in **mock serial mode** if `SERIAL_DEV` is unset — set it in
+`/etc/systemd/system/hil_bridge.service` and restart once the mini is attached.
+
+> This installer is provided for the Voron; **do not run it on this Windows dev
+> box.** Per the task, the physical mini is in use by another task — the service
+> and self-test run entirely against a mock serial.

--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -1,0 +1,127 @@
+"""bridge.py — HIL bridge service entrypoint.
+
+Wires serial_link + udp_relay + control_api under one asyncio loop.
+
+  app --UDP (verbatim COBS DATA18)--> udp_relay --(LIVE only)--> serial UART --> mini
+  app --WS  (JSON control)---------> control_api --CH_CMD--------> serial UART --> mini
+  mini --CH_TEL/LOG/RESP-----------> serial_link --> control_api --> WS clients
+
+Config via argparse or env (env fallbacks in parens):
+  --udp-port    (HIL_UDP_PORT,    default 8767)
+  --ws-port     (HIL_WS_PORT,     default 8788)   WebSocket control (Android)
+  --tcp-port    (HIL_TCP_PORT,    default 8789)   line-JSON TCP control (desktop app)
+  --bind        (HIL_BIND,        default 0.0.0.0)
+  --serial-dev  (HIL_SERIAL_DEV,  default None -> MockSerial, no hardware)
+  --baud        (HIL_BAUD,        default 921600)
+  --require-device  fail if the serial port can't open (default: degrade to mock)
+
+Both control ports serve the identical JSON verb schema (see PROTOCOL.md); set a
+port to 0 to disable that transport.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import signal
+
+from cobs import CH_LOG, CH_RESP, CH_TEL
+from control_api import ControlAPI
+from serial_link import SerialLink
+from udp_relay import UdpRelay
+
+log = logging.getLogger("bridge")
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="6DOF HIL network bridge (Voron-side relay)")
+    p.add_argument("--udp-port", type=int,
+                   default=int(os.environ.get("HIL_UDP_PORT", "8767")))
+    p.add_argument("--ws-port", type=int,
+                   default=int(os.environ.get("HIL_WS_PORT", "8788")))
+    p.add_argument("--tcp-port", type=int,
+                   default=int(os.environ.get("HIL_TCP_PORT", "8789")))
+    p.add_argument("--bind", default=os.environ.get("HIL_BIND", "0.0.0.0"))
+    p.add_argument("--serial-dev",
+                   default=os.environ.get("HIL_SERIAL_DEV") or None)
+    p.add_argument("--baud", type=int,
+                   default=int(os.environ.get("HIL_BAUD", "921600")))
+    p.add_argument("--require-device", action="store_true",
+                   default=os.environ.get("HIL_REQUIRE_DEVICE") == "1")
+    p.add_argument("--log-level", default=os.environ.get("HIL_LOG_LEVEL", "INFO"))
+    return p.parse_args(argv)
+
+
+class Bridge:
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.args = args
+        self.serial = SerialLink(
+            device=args.serial_dev,
+            baud=args.baud,
+            require_device=args.require_device,
+        )
+        self.udp = UdpRelay(
+            host=args.bind,
+            port=args.udp_port,
+            forward=self.serial.write_raw,
+            is_live=lambda: self.ctl.is_live(),
+        )
+        self.ctl = ControlAPI(
+            serial_link=self.serial,
+            host=args.bind,
+            ws_port=args.ws_port,
+            tcp_port=args.tcp_port,
+            udp_stats=self.udp.stats,
+        )
+        # Route device -> WS.
+        self.serial.on_frame(CH_TEL, self.ctl.on_tel)
+        self.serial.on_frame(CH_LOG, self.ctl.on_log)
+        self.serial.on_frame(CH_RESP, self.ctl.on_resp)
+
+    async def run(self) -> None:
+        self.serial.open()
+        self.serial.start()
+        await self.udp.start()
+        await self.ctl.start()
+        log.info("bridge up: udp:%d ws:%d tcp:%d serial:%s%s",
+                 self.args.udp_port, self.args.ws_port, self.args.tcp_port,
+                 self.args.serial_dev or "MOCK",
+                 " (mock)" if self.serial.is_mock else "")
+
+        stop = asyncio.Event()
+        loop = asyncio.get_event_loop()
+        for sig in (getattr(signal, "SIGINT", None), getattr(signal, "SIGTERM", None)):
+            if sig is None:
+                continue
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except NotImplementedError:
+                # Windows: add_signal_handler unsupported; Ctrl-C raises
+                # KeyboardInterrupt in the run() caller instead.
+                pass
+        await stop.wait()
+        await self.shutdown()
+
+    async def shutdown(self) -> None:
+        log.info("bridge shutting down")
+        await self.udp.stop()
+        await self.ctl.stop()
+        await self.serial.stop()
+
+
+def main(argv=None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    bridge = Bridge(args)
+    try:
+        asyncio.run(bridge.run())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/bridge/bridge.py
+++ b/bridge/bridge.py
@@ -49,6 +49,9 @@ def parse_args(argv=None) -> argparse.Namespace:
                    default=int(os.environ.get("HIL_BAUD", "921600")))
     p.add_argument("--require-device", action="store_true",
                    default=os.environ.get("HIL_REQUIRE_DEVICE") == "1")
+    p.add_argument("--auth-token", default=os.environ.get("HIL_AUTH_TOKEN") or None,
+                   help="optional shared token for control clients; unset = auth "
+                        "disabled (trusted-LAN default)")
     p.add_argument("--log-level", default=os.environ.get("HIL_LOG_LEVEL", "INFO"))
     return p.parse_args(argv)
 
@@ -73,6 +76,7 @@ class Bridge:
             ws_port=args.ws_port,
             tcp_port=args.tcp_port,
             udp_stats=self.udp.stats,
+            auth_token=args.auth_token,
         )
         # Route device -> WS.
         self.serial.on_frame(CH_TEL, self.ctl.on_tel)

--- a/bridge/cobs.py
+++ b/bridge/cobs.py
@@ -18,8 +18,10 @@ Channel IDs (from cobs.h):
     LOG    0x04  ESP->App  log/debug text
     RESP   0x05  ESP->App  command response text
     DATA18   0x06  App->ESP  BAKED motion data (18 bytes: 6x uint24 LE, low 18 bits)
-    DATA_RAW 0x07  App->ESP  RAW motion telemetry (6x int16 LE, pre-cueing);
-                             the ESP runs the cue engine on these (LIVE path).
+    DATA_RAW 0x07  App->ESP  RAW motion telemetry (24 bytes: 6x float32 LE,
+                             pre-cueing, app axis order surge=0/sway=1; the ESP
+                             runs the cue engine + swaps axes. LIVE path;
+                             matches .m6p v2 "M6P2" float32 format).
 """
 from __future__ import annotations
 
@@ -28,8 +30,8 @@ CH_CMD      = 0x02
 CH_TEL      = 0x03
 CH_LOG      = 0x04
 CH_RESP     = 0x05
-CH_DATA18   = 0x06   # baked motion (post-cueing 6x uint24)
-CH_DATA_RAW = 0x07   # raw motion telemetry (pre-cueing 6x int16); ESP cues it
+CH_DATA18   = 0x06   # baked motion (post-cueing 6x uint24 LE)
+CH_DATA_RAW = 0x07   # raw motion telemetry (pre-cueing 6x float32 LE); ESP cues it
 
 DELIMITER = 0x00
 
@@ -122,6 +124,19 @@ def make_data18(raw6: "list[int] | tuple[int, ...]") -> bytes:
         payload[i * 3 + 1] = (v >> 8) & 0xFF
         payload[i * 3 + 2] = (v >> 16) & 0xFF
     return frame(CH_DATA18, bytes(payload))
+
+
+def make_data_raw(raw6: "list[float] | tuple[float, ...]") -> bytes:
+    """Build a CH_DATA_RAW frame from six raw (pre-cueing) telemetry channels,
+    serialized as 6x float32 LE = 24 bytes, app axis order (surge=0, sway=1;
+    the ESP swaps axes after cueing). In production the APP builds these frames
+    and the bridge forwards them verbatim; this helper exists for tests and any
+    bridge-side generator. Matches the .m6p v2 "M6P2" float32 format."""
+    import struct
+    if len(raw6) != 6:
+        raise ValueError("DATA_RAW needs exactly 6 channel values")
+    payload = struct.pack("<6f", *(float(v) for v in raw6))
+    return frame(CH_DATA_RAW, payload)
 
 
 def make_cmd(cmd: str) -> bytes:

--- a/bridge/cobs.py
+++ b/bridge/cobs.py
@@ -1,0 +1,129 @@
+"""COBS codec + channel framing for the HIL bridge.
+
+Byte-parity port of Controller/include/cobs.h and the framing convention in
+Controller/main/CobsTransport.cpp / app/src/serial_port.cpp.
+
+Wire format (one frame):
+
+    COBS_encode( [channel_byte] + payload )  +  0x00 delimiter
+
+The channel byte is the FIRST byte of the pre-encode ("raw") frame; the COBS
+encoding then guarantees the encoded body contains no 0x00, so a single 0x00
+byte delimits frames on the wire. The caller appends the delimiter (matches
+cobs.h's contract: cobs_encode returns the length WITHOUT the trailing 0x00).
+
+Channel IDs (from cobs.h):
+    CMD    0x02  App->ESP  ASCII command string
+    TEL    0x03  ESP->App  telemetry (48 bytes: 12x float32 LE)
+    LOG    0x04  ESP->App  log/debug text
+    RESP   0x05  ESP->App  command response text
+    DATA18   0x06  App->ESP  BAKED motion data (18 bytes: 6x uint24 LE, low 18 bits)
+    DATA_RAW 0x07  App->ESP  RAW motion telemetry (6x int16 LE, pre-cueing);
+                             the ESP runs the cue engine on these (LIVE path).
+"""
+from __future__ import annotations
+
+# ── Channel IDs (must match Controller/include/cobs.h) ──────────────────────
+CH_CMD      = 0x02
+CH_TEL      = 0x03
+CH_LOG      = 0x04
+CH_RESP     = 0x05
+CH_DATA18   = 0x06   # baked motion (post-cueing 6x uint24)
+CH_DATA_RAW = 0x07   # raw motion telemetry (pre-cueing 6x int16); ESP cues it
+
+DELIMITER = 0x00
+
+CHANNEL_NAMES = {
+    CH_CMD:      "CMD",
+    CH_TEL:      "TEL",
+    CH_LOG:      "LOG",
+    CH_RESP:     "RESP",
+    CH_DATA18:   "DATA18",
+    CH_DATA_RAW: "DATA_RAW",
+}
+
+
+def cobs_encode(data: bytes) -> bytes:
+    """COBS-encode ``data``. Returns encoded bytes WITHOUT the trailing 0x00
+    delimiter (byte-for-byte equivalent to cobs.h ``cobs_encode``)."""
+    out = bytearray()
+    code_idx = len(out)
+    out.append(0)          # placeholder for the current code byte
+    code = 1
+    for b in data:
+        if b == 0:
+            out[code_idx] = code
+            code_idx = len(out)
+            out.append(0)  # placeholder
+            code = 1
+        else:
+            out.append(b)
+            code += 1
+            if code == 0xFF:
+                out[code_idx] = code
+                code_idx = len(out)
+                out.append(0)
+                code = 1
+    out[code_idx] = code
+    return bytes(out)
+
+
+def cobs_decode(data: bytes) -> bytes | None:
+    """COBS-decode ``data`` (the bytes BETWEEN 0x00 delimiters, no zeros).
+    Returns the decoded payload, or ``None`` on a framing error (mirrors the
+    cobs.h ``return -1``)."""
+    if len(data) == 0:
+        return b""
+    out = bytearray()
+    i = 0
+    n = len(data)
+    while i < n:
+        code = data[i]
+        i += 1
+        if code == 0:
+            return None
+        count = code - 1
+        if i + count > n:
+            return None
+        out += data[i:i + count]
+        i += count
+        if code < 0xFF and i < n:
+            out.append(0)
+    return bytes(out)
+
+
+def frame(channel: int, payload: bytes = b"") -> bytes:
+    """Build a complete on-wire frame: COBS([channel]+payload) + 0x00.
+
+    Includes the trailing delimiter — this is what gets written to the UART or
+    carried verbatim as a UDP datagram body."""
+    raw = bytes([channel]) + payload
+    return cobs_encode(raw) + bytes([DELIMITER])
+
+
+def unframe(encoded: bytes) -> tuple[int | None, bytes]:
+    """Decode a single frame's bytes (delimiter already stripped) into
+    ``(channel, payload)``. Returns ``(None, b"")`` on a decode/empty error."""
+    decoded = cobs_decode(encoded)
+    if decoded is None or len(decoded) < 1:
+        return None, b""
+    return decoded[0], decoded[1:]
+
+
+def make_data18(raw6: "list[int] | tuple[int, ...]") -> bytes:
+    """Build a CH_DATA18 frame from six channel values (each masked to 18
+    bits, serialized as uint24 LE) — matches SerialPort::sendCobsData."""
+    if len(raw6) != 6:
+        raise ValueError("DATA18 needs exactly 6 channel values")
+    payload = bytearray(18)
+    for i, val in enumerate(raw6):
+        v = int(val) & 0x3FFFF
+        payload[i * 3]     = v & 0xFF
+        payload[i * 3 + 1] = (v >> 8) & 0xFF
+        payload[i * 3 + 2] = (v >> 16) & 0xFF
+    return frame(CH_DATA18, bytes(payload))
+
+
+def make_cmd(cmd: str) -> bytes:
+    """Build a CH_CMD frame from an ASCII command string."""
+    return frame(CH_CMD, cmd.encode("ascii"))

--- a/bridge/control_api.py
+++ b/bridge/control_api.py
@@ -21,10 +21,9 @@ pre-cueing) verbatim to the ESP, which runs the single on-device cue engine.
 The bridge does NOT cue. See PROTOCOL.md.
 
 State machine (set_source):
-  OFF  -> "PLAY:STOP"  (halt motion) + "SOURCE:OFF" (forward-compat; firmware
-          SOURCE: support lands in Phase 3 — HIL_BRIDGE.md) + gate UDP.
-          NOTE: HIL_BRIDGE.md wants OFF to HOME the platform; no HOME cmd exists
-          yet (Phase 3), so OFF = STOP-only for now. See OPEN QUESTIONS.
+  OFF  -> "PLAY:STOP" (halt) + "ZERO" (HOME the platform — locked round-2
+          decision; ZERO homes on today's firmware) + "SOURCE:OFF" (fwd-compat;
+          firmware SOURCE: support lands in Phase 3 — HIL_BRIDGE.md) + gate UDP.
   DEMO -> "SOURCE:DEMO" (fwd-compat) + "PLAY:START" (on-device playback).
   LIVE -> open the UDP gate (streamed RAW motion from the app).
 
@@ -56,6 +55,11 @@ class _Client:
     implement ``_raw_send(text)``."""
     kind = "?"
 
+    def __init__(self) -> None:
+        # Auth gate. When the server has no token configured this is set True at
+        # connect; otherwise it flips True only after a valid {"auth":...} msg.
+        self.authed = False
+
     async def send(self, obj: dict) -> bool:
         try:
             await self._raw_send(json.dumps(obj))
@@ -71,6 +75,7 @@ class _WsClient(_Client):
     kind = "ws"
 
     def __init__(self, ws) -> None:
+        super().__init__()
         self._ws = ws
 
     async def _raw_send(self, text: str) -> None:
@@ -81,6 +86,7 @@ class _TcpClient(_Client):
     kind = "tcp"
 
     def __init__(self, writer: asyncio.StreamWriter) -> None:
+        super().__init__()
         self._writer = writer
 
     async def _raw_send(self, text: str) -> None:
@@ -92,12 +98,18 @@ class _TcpClient(_Client):
 class ControlAPI:
     def __init__(self, serial_link, host: str = "0.0.0.0",
                  ws_port: int = 8788, tcp_port: int = 8789,
-                 udp_stats: Optional[dict] = None) -> None:
+                 udp_stats: Optional[dict] = None,
+                 auth_token: Optional[str] = None) -> None:
         self._serial = serial_link
         self.host = host
         self.ws_port = ws_port
         self.tcp_port = tcp_port
         self._udp_stats = udp_stats if udp_stats is not None else {}
+        # Optional shared-token auth. None => DISABLED (trusted-LAN default, in
+        # parity with the app's :8770 server). When set, a client must send
+        # {"auth":"<token>"} as its first message before any verb is accepted.
+        # This is the seam for the Android / off-LAN phase — see PROTOCOL.md.
+        self._auth_token = auth_token
         self._clients: Set[_Client] = set()
         self._ws_server = None
         self._tcp_server: Optional[asyncio.AbstractServer] = None
@@ -185,10 +197,15 @@ class ControlAPI:
 
     async def _on_connect(self, client: _Client) -> None:
         self._clients.add(client)
+        # Auth disabled (no token) => client is authed immediately.
+        client.authed = self._auth_token is None
         log.info("ctl: %s client connected (%d total)", client.kind, len(self._clients))
         await client.send({"type": "hello", "api_version": API_VERSION,
-                           "service": "hil-bridge", "transport": client.kind})
-        await client.send(self._status_event())
+                           "service": "hil-bridge", "transport": client.kind,
+                           "auth_required": not client.authed})
+        # Only leak state to already-authed clients.
+        if client.authed:
+            await client.send(self._status_event())
 
     def _on_disconnect(self, client: _Client) -> None:
         self._clients.discard(client)
@@ -200,6 +217,11 @@ class ControlAPI:
         except (ValueError, TypeError):
             await client.send({"type": "resp", "ok": False, "error": "invalid_json"})
             return
+        # Auth gate (no-op when auth is disabled — client.authed is already
+        # True). When enabled, the first message must be {"auth":"<token>"}.
+        if not client.authed:
+            if not await self._try_auth(client, msg):
+                return
         verb = msg.get("verb") or msg.get("cmd")
         req_id = msg.get("id")
         try:
@@ -213,6 +235,21 @@ class ControlAPI:
         except _ApiError as exc:
             await client.send({"type": "resp", "verb": verb, "ok": False,
                                "id": req_id, "error": str(exc)})
+
+    async def _try_auth(self, client: _Client, msg: dict) -> bool:
+        """Handle the token handshake for an un-authed client. Returns True iff
+        the client is now authed (and the caller may proceed to dispatch this
+        same message if it also carried a verb — but the handshake message is
+        auth-only by convention). Only reached when auth is ENABLED."""
+        token = msg.get("auth")
+        if token is not None and token == self._auth_token:
+            client.authed = True
+            await client.send({"type": "resp", "verb": "auth", "ok": True})
+            await client.send(self._status_event())
+            return False   # handshake consumed; verb (if any) not dispatched
+        await client.send({"type": "resp", "verb": "auth", "ok": False,
+                           "error": "auth_required"})
+        return False
 
     async def _dispatch(self, verb: Optional[str], msg: dict) -> Optional[dict]:
         if verb == "set_source":
@@ -245,6 +282,9 @@ class ControlAPI:
         self.source = source
         if source == SOURCE_OFF:
             self._serial.send_cmd("PLAY:STOP")
+            # HOME the platform (locked round-2 decision: OFF + startup home).
+            # No SOURCE:/HOME firmware cmd exists yet, but ZERO homes today.
+            self._serial.send_cmd("ZERO")
             # Forward-compat: firmware SOURCE: support arrives in Phase 3
             # (HIL_BRIDGE.md). Harmless unknown-command today.
             self._serial.send_cmd("SOURCE:OFF")

--- a/bridge/control_api.py
+++ b/bridge/control_api.py
@@ -1,0 +1,360 @@
+"""control_api.py — dual-transport JSON control server for the HIL bridge.
+
+Transport-neutral, versioned JSON. ONE message schema is served over TWO
+transports so every client uses its most convenient stack:
+  * WebSocket   — for the Android control client (and anything WS-native).
+  * line-JSON TCP — one JSON object per line ('\\n'-delimited), so the desktop
+    app reuses its existing winsock + cJSON code (same style as the app's :8770
+    control server).
+Both transports share the exact same verbs, request/response, and event schema.
+See bridge/PROTOCOL.md.
+
+Responsibilities
+  * Own the OFF / DEMO / LIVE source state machine (single source of truth; the
+    UDP relay consults ``is_live()`` here).
+  * Translate control verbs into CH_CMD strings sent over the serial link.
+  * Fan out device frames (CH_TEL / CH_LOG / CH_RESP) and status changes to all
+    connected clients (WS + TCP) as JSON events.
+
+Motion model: LIVE forwards RAW motion telemetry (COBS CH_DATA_RAW = 0x07,
+pre-cueing) verbatim to the ESP, which runs the single on-device cue engine.
+The bridge does NOT cue. See PROTOCOL.md.
+
+State machine (set_source):
+  OFF  -> "PLAY:STOP"  (halt motion) + "SOURCE:OFF" (forward-compat; firmware
+          SOURCE: support lands in Phase 3 — HIL_BRIDGE.md) + gate UDP.
+          NOTE: HIL_BRIDGE.md wants OFF to HOME the platform; no HOME cmd exists
+          yet (Phase 3), so OFF = STOP-only for now. See OPEN QUESTIONS.
+  DEMO -> "SOURCE:DEMO" (fwd-compat) + "PLAY:START" (on-device playback).
+  LIVE -> open the UDP gate (streamed RAW motion from the app).
+
+Verbs: set_source, play, status, select_demo, boot_source, mem, list_files,
+       upload_file (chunked, stub), delete_file (stub), flash_firmware (stub).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Optional, Set
+
+import websockets
+
+log = logging.getLogger("bridge.ctl")
+
+API_VERSION = 1
+
+SOURCE_OFF = "OFF"
+SOURCE_DEMO = "DEMO"
+SOURCE_LIVE = "LIVE"
+VALID_SOURCES = (SOURCE_OFF, SOURCE_DEMO, SOURCE_LIVE)
+
+
+class _Client:
+    """Wraps a connected client so broadcast is transport-agnostic. Subclasses
+    implement ``_raw_send(text)``."""
+    kind = "?"
+
+    async def send(self, obj: dict) -> bool:
+        try:
+            await self._raw_send(json.dumps(obj))
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def _raw_send(self, text: str) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+class _WsClient(_Client):
+    kind = "ws"
+
+    def __init__(self, ws) -> None:
+        self._ws = ws
+
+    async def _raw_send(self, text: str) -> None:
+        await self._ws.send(text)
+
+
+class _TcpClient(_Client):
+    kind = "tcp"
+
+    def __init__(self, writer: asyncio.StreamWriter) -> None:
+        self._writer = writer
+
+    async def _raw_send(self, text: str) -> None:
+        # line-JSON: exactly one object per line.
+        self._writer.write(text.encode("utf-8") + b"\n")
+        await self._writer.drain()
+
+
+class ControlAPI:
+    def __init__(self, serial_link, host: str = "0.0.0.0",
+                 ws_port: int = 8788, tcp_port: int = 8789,
+                 udp_stats: Optional[dict] = None) -> None:
+        self._serial = serial_link
+        self.host = host
+        self.ws_port = ws_port
+        self.tcp_port = tcp_port
+        self._udp_stats = udp_stats if udp_stats is not None else {}
+        self._clients: Set[_Client] = set()
+        self._ws_server = None
+        self._tcp_server: Optional[asyncio.AbstractServer] = None
+
+        # ── source state machine ────────────────────────────────────────
+        self.source = SOURCE_OFF        # motion gated at boot (safe idle)
+        self.boot_source = SOURCE_OFF
+        self.selected_demo: Optional[str] = None
+        self.play_state = "stopped"     # stopped | playing | looping
+        self.started_at = time.time()
+
+    # ── UDP gate ────────────────────────────────────────────────────────
+    def is_live(self) -> bool:
+        return self.source == SOURCE_LIVE
+
+    # ── server lifecycle ────────────────────────────────────────────────
+    async def start(self) -> None:
+        if self.ws_port:
+            self._ws_server = await websockets.serve(
+                self._handle_ws, self.host, self.ws_port)
+            log.info("ctl: websocket server on ws://%s:%d", self.host, self.ws_port)
+        if self.tcp_port:
+            self._tcp_server = await asyncio.start_server(
+                self._handle_tcp, self.host, self.tcp_port)
+            log.info("ctl: line-JSON TCP server on tcp://%s:%d", self.host, self.tcp_port)
+
+    async def stop(self) -> None:
+        if self._ws_server is not None:
+            self._ws_server.close()
+            await self._ws_server.wait_closed()
+            self._ws_server = None
+        if self._tcp_server is not None:
+            self._tcp_server.close()
+            await self._tcp_server.wait_closed()
+            self._tcp_server = None
+
+    # ── device -> client fan-out (wire to serial_link.on_frame) ─────────
+    def on_tel(self, payload: bytes) -> None:
+        # 48 bytes = 12x float32 LE (angles[6] + positions[6]); forward as hex
+        # so the schema stays transport-neutral (clients decode as needed).
+        self._broadcast({"type": "event", "event": "telemetry",
+                         "channel": "TEL", "hex": payload.hex(),
+                         "len": len(payload)})
+
+    def on_log(self, payload: bytes) -> None:
+        self._broadcast({"type": "event", "event": "log", "channel": "LOG",
+                         "text": payload.decode("utf-8", "replace")})
+
+    def on_resp(self, payload: bytes) -> None:
+        self._broadcast({"type": "event", "event": "resp", "channel": "RESP",
+                         "text": payload.decode("utf-8", "replace")})
+
+    # ── connection handlers ─────────────────────────────────────────────
+    async def _handle_ws(self, ws) -> None:
+        client = _WsClient(ws)
+        await self._on_connect(client)
+        try:
+            async for raw in ws:
+                await self._on_message(client, raw)
+        except websockets.ConnectionClosed:
+            pass
+        finally:
+            self._on_disconnect(client)
+
+    async def _handle_tcp(self, reader: asyncio.StreamReader,
+                          writer: asyncio.StreamWriter) -> None:
+        client = _TcpClient(writer)
+        await self._on_connect(client)
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:               # EOF
+                    break
+                text = line.decode("utf-8", "replace").strip()
+                if text:
+                    await self._on_message(client, text)
+        except (ConnectionError, asyncio.IncompleteReadError):
+            pass
+        finally:
+            self._on_disconnect(client)
+            try:
+                writer.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def _on_connect(self, client: _Client) -> None:
+        self._clients.add(client)
+        log.info("ctl: %s client connected (%d total)", client.kind, len(self._clients))
+        await client.send({"type": "hello", "api_version": API_VERSION,
+                           "service": "hil-bridge", "transport": client.kind})
+        await client.send(self._status_event())
+
+    def _on_disconnect(self, client: _Client) -> None:
+        self._clients.discard(client)
+        log.info("ctl: %s client disconnected (%d left)", client.kind, len(self._clients))
+
+    async def _on_message(self, client: _Client, raw: str) -> None:
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            await client.send({"type": "resp", "ok": False, "error": "invalid_json"})
+            return
+        verb = msg.get("verb") or msg.get("cmd")
+        req_id = msg.get("id")
+        try:
+            result = await self._dispatch(verb, msg)
+            resp = {"type": "resp", "verb": verb, "ok": True}
+            if req_id is not None:
+                resp["id"] = req_id
+            if result:
+                resp.update(result)
+            await client.send(resp)
+        except _ApiError as exc:
+            await client.send({"type": "resp", "verb": verb, "ok": False,
+                               "id": req_id, "error": str(exc)})
+
+    async def _dispatch(self, verb: Optional[str], msg: dict) -> Optional[dict]:
+        if verb == "set_source":
+            return self._set_source(msg.get("source"))
+        if verb == "play":
+            return self._play(msg.get("action"))
+        if verb == "status":
+            self._broadcast(self._status_event())
+            return self._status_body()
+        if verb == "select_demo":
+            return self._select_demo(msg.get("name"))
+        if verb == "boot_source":
+            return self._set_boot_source(msg.get("source"))
+        if verb == "mem":
+            return self._mem()
+        if verb == "list_files":
+            return self._list_files()
+        if verb == "upload_file":
+            return self._upload_file(msg)
+        if verb == "delete_file":
+            return self._delete_file(msg.get("name"))
+        if verb == "flash_firmware":
+            return self._flash_firmware(msg)
+        raise _ApiError(f"unknown_verb:{verb}")
+
+    # ── verb implementations ────────────────────────────────────────────
+    def _set_source(self, source: Optional[str]) -> dict:
+        if source not in VALID_SOURCES:
+            raise _ApiError(f"bad_source:{source}")
+        self.source = source
+        if source == SOURCE_OFF:
+            self._serial.send_cmd("PLAY:STOP")
+            # Forward-compat: firmware SOURCE: support arrives in Phase 3
+            # (HIL_BRIDGE.md). Harmless unknown-command today.
+            self._serial.send_cmd("SOURCE:OFF")
+            self.play_state = "stopped"
+        elif source == SOURCE_DEMO:
+            self._serial.send_cmd("SOURCE:DEMO")   # forward-compat (Phase 3)
+            self._serial.send_cmd("PLAY:START")
+            self.play_state = "playing"
+        elif source == SOURCE_LIVE:
+            self._serial.send_cmd("SOURCE:LIVE")   # forward-compat (Phase 3)
+            # LIVE just opens the UDP gate; no PLAY needed. Ensure on-device
+            # demo playback isn't running.
+            self._serial.send_cmd("PLAY:STOP")
+            self.play_state = "stopped"
+        self._broadcast(self._status_event())
+        return {"source": self.source, "motion_gated": self.source != SOURCE_LIVE}
+
+    def _play(self, action: Optional[str]) -> dict:
+        mapping = {"start": "PLAY:START", "stop": "PLAY:STOP", "loop": "PLAY:LOOP"}
+        cmd = mapping.get(action)
+        if cmd is None:
+            raise _ApiError(f"bad_play_action:{action}")
+        self._serial.send_cmd(cmd)
+        self.play_state = {"start": "playing", "stop": "stopped",
+                           "loop": "looping"}[action]
+        self._broadcast(self._status_event())
+        return {"play_state": self.play_state}
+
+    def _select_demo(self, name: Optional[str]) -> dict:
+        if not name:
+            raise _ApiError("missing_name")
+        self.selected_demo = name
+        # Forward-compat command; on-device selection lands with the seq
+        # partition work (Phase 3).
+        self._serial.send_cmd(f"SELECT:{name}")
+        self._broadcast(self._status_event())
+        return {"selected_demo": name}
+
+    def _set_boot_source(self, source: Optional[str]) -> dict:
+        if source not in VALID_SOURCES:
+            raise _ApiError(f"bad_source:{source}")
+        self.boot_source = source
+        # Reuse the play_on_boot NVS pattern (generalized to boot_source in
+        # Phase 3, HIL_BRIDGE.md).
+        self._serial.send_cmd(f"BOOT_SOURCE:{source}")
+        return {"boot_source": source}
+
+    def _mem(self) -> dict:
+        # Real used/free comes back over CH_RESP once the firmware file ops
+        # exist (Phase 3). Query now so a listening client sees the RESP event.
+        self._serial.send_cmd("MEM?")
+        return {"queried": True, "note": "used/free arrives as a RESP event (Phase 3 firmware)"}
+
+    def _list_files(self) -> dict:
+        self._serial.send_cmd("LIST?")
+        return {"files": [], "note": "device file listing arrives as RESP events (Phase 3 firmware)"}
+
+    def _upload_file(self, msg: dict) -> dict:
+        # STUB (chunked). Real impl: erase seq/LittleFS region, stream chunks
+        # over CH_CMD/a data channel, verify CRC. Accept the handshake shape now
+        # so the app/Android client can be built against it.
+        name = msg.get("name")
+        total = msg.get("total_chunks")
+        idx = msg.get("chunk_index")
+        if not name:
+            raise _ApiError("missing_name")
+        return {"accepted": True, "name": name, "chunk_index": idx,
+                "total_chunks": total, "stub": True}
+
+    def _delete_file(self, name: Optional[str]) -> dict:
+        if not name:
+            raise _ApiError("missing_name")
+        return {"deleted": name, "stub": True}
+
+    def _flash_firmware(self, msg: dict) -> dict:
+        # STUB. Real impl: esptool write_flash over the USB port (bridge owns
+        # the serial device). Nice-to-have (Phase 4).
+        return {"accepted": True, "stub": True,
+                "note": "esptool flash over USB — Phase 4"}
+
+    # ── status + broadcast ──────────────────────────────────────────────
+    def _status_body(self) -> dict:
+        return {
+            "api_version": API_VERSION,
+            "source": self.source,
+            "boot_source": self.boot_source,
+            "play_state": self.play_state,
+            "selected_demo": self.selected_demo,
+            "motion_gated": self.source != SOURCE_LIVE,
+            "serial_mock": getattr(self._serial, "is_mock", False),
+            "serial_device": getattr(self._serial, "device", None),
+            "udp": dict(self._udp_stats),
+            "clients": len(self._clients),
+            "uptime_s": round(time.time() - self.started_at, 1),
+        }
+
+    def _status_event(self) -> dict:
+        return {"type": "event", "event": "status", **self._status_body()}
+
+    def _broadcast(self, obj: dict) -> None:
+        if not self._clients:
+            return
+        for client in list(self._clients):
+            asyncio.ensure_future(self._safe_send(client, obj))
+
+    async def _safe_send(self, client: _Client, obj: dict) -> None:
+        ok = await client.send(obj)
+        if not ok:
+            self._clients.discard(client)
+
+
+class _ApiError(Exception):
+    pass

--- a/bridge/hil_bridge.service
+++ b/bridge/hil_bridge.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=6DOF HIL Network Bridge (UDP motion relay + WebSocket control -> ESP32 mini over USB COBS)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Installed by install.sh; edit these to match the Voron.
+User=knaufinator
+WorkingDirectory=/opt/hil-bridge
+# Serial device: the ESP32 mini on USB. Leave HIL_SERIAL_DEV unset to run in
+# MOCK mode (no hardware) for a smoke test.
+Environment=HIL_SERIAL_DEV=/dev/serial/by-id/usb-ESP32-mini
+Environment=HIL_BAUD=921600
+Environment=HIL_UDP_PORT=8767
+Environment=HIL_WS_PORT=8788
+Environment=HIL_TCP_PORT=8789
+Environment=HIL_BIND=0.0.0.0
+Environment=HIL_LOG_LEVEL=INFO
+ExecStart=/opt/hil-bridge/.venv/bin/python /opt/hil-bridge/bridge.py
+Restart=on-failure
+RestartSec=2
+# Access to the USB serial device (Debian/Ubuntu: dialout).
+SupplementaryGroups=dialout
+
+[Install]
+WantedBy=multi-user.target

--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# install.sh — one-command installer for the HIL bridge on the Voron.
+# This IS the "create service" action from HIL_BRIDGE.md.
+#
+# Run ON the Voron (knaufinator@192.168.1.168), from a checkout of this repo:
+#   cd 6DOF-Rotary-Stewart-Motion-Simulator/bridge
+#   sudo ./install.sh
+#
+# It: copies bridge/ to /opt/hil-bridge, builds a venv, installs deps, installs
+# + enables the systemd unit, and starts the service. Idempotent (re-runnable).
+#
+# Env overrides:
+#   DEST=/opt/hil-bridge  SERVICE_USER=knaufinator  SERIAL_DEV=/dev/serial/by-id/...
+set -euo pipefail
+
+DEST="${DEST:-/opt/hil-bridge}"
+SERVICE_USER="${SERVICE_USER:-knaufinator}"
+SERIAL_DEV="${SERIAL_DEV:-}"        # empty => MOCK mode until you set it
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root (sudo ./install.sh)." >&2
+  exit 1
+fi
+
+echo "==> Installing HIL bridge to ${DEST} (user: ${SERVICE_USER})"
+
+# 1. Copy source (exclude venv + caches).
+mkdir -p "${DEST}"
+for f in cobs.py serial_link.py udp_relay.py control_api.py bridge.py \
+         requirements.txt test_client.py selftest.py PROTOCOL.md README.md; do
+  install -m 0644 "${SRC_DIR}/${f}" "${DEST}/${f}"
+done
+chown -R "${SERVICE_USER}:${SERVICE_USER}" "${DEST}"
+
+# 2. venv + deps.
+echo "==> Creating venv + installing dependencies"
+sudo -u "${SERVICE_USER}" python3 -m venv "${DEST}/.venv"
+sudo -u "${SERVICE_USER}" "${DEST}/.venv/bin/pip" install --upgrade pip
+sudo -u "${SERVICE_USER}" "${DEST}/.venv/bin/pip" install -r "${DEST}/requirements.txt"
+
+# 3. Ensure the service user can reach the USB serial device.
+if getent group dialout >/dev/null; then
+  usermod -aG dialout "${SERVICE_USER}" || true
+fi
+
+# 4. Install the systemd unit, patching the serial device if provided.
+echo "==> Installing systemd unit"
+UNIT=/etc/systemd/system/hil_bridge.service
+install -m 0644 "${SRC_DIR}/hil_bridge.service" "${UNIT}"
+sed -i "s#^WorkingDirectory=.*#WorkingDirectory=${DEST}#" "${UNIT}"
+sed -i "s#^User=.*#User=${SERVICE_USER}#" "${UNIT}"
+sed -i "s#^ExecStart=.*#ExecStart=${DEST}/.venv/bin/python ${DEST}/bridge.py#" "${UNIT}"
+if [[ -n "${SERIAL_DEV}" ]]; then
+  sed -i "s#^Environment=HIL_SERIAL_DEV=.*#Environment=HIL_SERIAL_DEV=${SERIAL_DEV}#" "${UNIT}"
+fi
+
+# 5. Enable + (re)start.
+systemctl daemon-reload
+systemctl enable hil_bridge.service
+systemctl restart hil_bridge.service
+
+echo "==> Done. Status:"
+systemctl --no-pager --full status hil_bridge.service || true
+echo
+echo "Logs:   journalctl -u hil_bridge.service -f"
+echo "WS:     ws://<voron-ip>:8788   UDP motion: <voron-ip>:8767"
+if [[ -z "${SERIAL_DEV}" ]]; then
+  echo "NOTE: running in MOCK serial mode (HIL_SERIAL_DEV unset). Set it in ${UNIT} and 'systemctl restart hil_bridge' once the mini is attached."
+fi

--- a/bridge/requirements.txt
+++ b/bridge/requirements.txt
@@ -1,0 +1,2 @@
+pyserial>=3.5
+websockets>=12.0

--- a/bridge/selftest.py
+++ b/bridge/selftest.py
@@ -20,7 +20,8 @@ import socket
 import sys
 
 import cobs
-from cobs import CH_CMD, CH_DATA18, cobs_decode, cobs_encode, frame, make_data18, unframe
+from cobs import (CH_CMD, CH_DATA18, CH_DATA_RAW, cobs_decode, cobs_encode, frame,
+                  make_data18, make_data_raw, unframe)
 from control_api import ControlAPI
 from serial_link import MockSerial, SerialLink
 from udp_relay import UdpRelay
@@ -91,6 +92,17 @@ def test_cobs() -> None:
     check("DATA18 uint24 LE + 18-bit mask",
           p3[0:3] == bytes([0x45, 0x23, 0x01]),
           f"got {p3[0:3].hex()}")
+
+    # DATA_RAW frame: CH_DATA_RAW channel + 24-byte payload = 6x float32 LE.
+    import struct
+    fr = make_data_raw([1.0, -2.5, 3.0, 0.0, 0.0, 0.0])
+    chr_, praw = unframe(fr[:-1])
+    check("DATA_RAW frame: channel + 24-byte (6x float32 LE) payload",
+          chr_ == CH_DATA_RAW and len(praw) == 24 and fr[-1] == 0x00,
+          f"ch={chr_} plen={len(praw)}")
+    check("DATA_RAW float32 LE values round-trip",
+          struct.unpack("<6f", praw) == (1.0, -2.5, 3.0, 0.0, 0.0, 0.0),
+          f"got {struct.unpack('<6f', praw)}")
 
 
 # ── Test 2: UDP loopback gating ──────────────────────────────────────────────
@@ -181,13 +193,13 @@ async def test_ws() -> None:
         check("received set_source resp", got_resp)
         check("is_live() now true", ctl.is_live() is True)
 
-        # OFF must emit PLAY:STOP over serial (framed CMD)
+        # OFF must emit PLAY:STOP + ZERO (home) + SOURCE:OFF over serial
         mock.written.clear()
         await ws.send(json.dumps({"verb": "set_source", "source": "OFF", "id": 2}))
         await asyncio.sleep(0.2)
-        # decode what was written; expect a PLAY:STOP CMD frame present
         cmds = _decode_cmd_frames(mock.written)
         check("OFF sends PLAY:STOP over serial", "PLAY:STOP" in cmds, f"cmds={cmds}")
+        check("OFF sends ZERO (home) over serial", "ZERO" in cmds, f"cmds={cmds}")
         check("OFF sends SOURCE:OFF (forward-compat)", "SOURCE:OFF" in cmds,
               f"cmds={cmds}")
         check("is_live() false after OFF", ctl.is_live() is False)
@@ -253,6 +265,60 @@ async def test_tcp() -> None:
     await link.stop()
 
 
+# ── Test 5: auth handshake seam (enabled) ───────────────────────────────────
+async def test_auth() -> None:
+    print("Test 5: auth handshake seam (token enabled)")
+    import websockets
+
+    mock = MockSerial()
+    link = SerialLink(transport=mock)
+    link.open()
+    link.start()
+
+    port = _free_tcp_port()
+    ctl = ControlAPI(link, host="127.0.0.1", ws_port=port, tcp_port=0,
+                     auth_token="s3cret")
+    await ctl.start()
+
+    async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:
+        hello = json.loads(await ws.recv())
+        check("auth: hello says auth_required=true", hello.get("auth_required") is True)
+
+        # A verb before auth is rejected (no status snapshot leaked).
+        await ws.send(json.dumps({"verb": "status"}))
+        rej = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+        check("auth: verb before auth rejected",
+              rej.get("verb") == "auth" and rej.get("ok") is False
+              and rej.get("error") == "auth_required")
+
+        # Wrong token rejected.
+        await ws.send(json.dumps({"auth": "wrong"}))
+        bad = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+        check("auth: wrong token rejected", bad.get("ok") is False)
+
+        # Correct token -> ok + status snapshot.
+        await ws.send(json.dumps({"auth": "s3cret"}))
+        ok = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+        check("auth: correct token accepted",
+              ok.get("verb") == "auth" and ok.get("ok") is True)
+        snap = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+        check("auth: status snapshot delivered after auth",
+              snap.get("event") == "status")
+
+        # Now verbs work.
+        await ws.send(json.dumps({"verb": "set_source", "source": "LIVE", "id": 9}))
+        got = False
+        for _ in range(4):
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+            if msg.get("type") == "resp" and msg.get("verb") == "set_source":
+                got = msg.get("ok") is True
+                break
+        check("auth: verbs accepted after auth", got)
+
+    await ctl.stop()
+    await link.stop()
+
+
 # ── helpers ─────────────────────────────────────────────────────────────────
 def _decode_cmd_frames(chunks: list[bytes]) -> list[str]:
     out: list[str] = []
@@ -285,6 +351,7 @@ async def _async_main() -> None:
     await test_udp()
     await test_ws()
     await test_tcp()
+    await test_auth()
 
 
 def main() -> int:

--- a/bridge/selftest.py
+++ b/bridge/selftest.py
@@ -1,0 +1,303 @@
+"""selftest.py — hardware-free self-test for the HIL bridge.
+
+Run:  python selftest.py     (needs the `websockets` dep; pyserial NOT required)
+
+Verifies:
+  1. cobs.py encode/decode round-trips + a hand-computed frame matches cobs.h's
+     scheme (channel byte prefix, no zeros in the encoded body, trailing 0x00).
+  2. UDP loopback: a datagram sent to udp_relay reaches a MOCK serial sink ONLY
+     in LIVE (dropped in OFF/DEMO).
+  3. A WS client connects, set_source, and receives a status event — all against
+     a MOCK serial (no real port).
+
+Exit code 0 = all green.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import sys
+
+import cobs
+from cobs import CH_CMD, CH_DATA18, cobs_decode, cobs_encode, frame, make_data18, unframe
+from control_api import ControlAPI
+from serial_link import MockSerial, SerialLink
+from udp_relay import UdpRelay
+
+PASS = "PASS"
+FAIL = "FAIL"
+_failures: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    tag = PASS if cond else FAIL
+    print(f"  [{tag}] {name}" + (f" — {detail}" if detail and not cond else ""))
+    if not cond:
+        _failures.append(name)
+
+
+# ── Test 1: COBS parity ─────────────────────────────────────────────────────
+def test_cobs() -> None:
+    print("Test 1: COBS codec parity")
+
+    # round-trips
+    vectors = [
+        b"",
+        b"\x00",
+        b"\x00\x00\x00",
+        b"\x01\x02\x03",
+        b"hello world",
+        bytes(range(256)),
+        b"\x11" * 300,          # crosses the 0xFF (254-byte) code-block boundary
+        bytes([0] * 260),
+    ]
+    ok = True
+    for v in vectors:
+        enc = cobs_encode(v)
+        if 0x00 in enc:
+            ok = False
+            break
+        dec = cobs_decode(enc)
+        if dec != v:
+            ok = False
+            break
+    check("round-trip (incl. zeros + >254B blocks)", ok)
+
+    # Hand-computed frame. CH_CMD (0x02) + "AB" (0x41,0x42) => raw 02 41 42.
+    # No zero bytes, so COBS prepends a single code byte = len+1 = 4 (0x04)
+    # and copies the bytes verbatim: 04 02 41 42, then the 0x00 delimiter.
+    expected = bytes([0x04, 0x02, 0x41, 0x42, 0x00])
+    got = frame(CH_CMD, b"AB")
+    check("hand-computed CMD frame == 04 02 41 42 00", got == expected,
+          f"got {got.hex()}")
+
+    # unframe inverts frame()
+    ch, payload = unframe(got[:-1])   # strip delimiter
+    check("unframe recovers channel+payload", ch == CH_CMD and payload == b"AB",
+          f"ch={ch} payload={payload!r}")
+
+    # A DATA18 frame: correct channel, 18-byte payload, ends in 0x00, body has
+    # no interior zeros.
+    f = make_data18([1, 2, 3, 4, 5, 6])
+    ch2, p2 = unframe(f[:-1])
+    check("DATA18 frame: channel + 18-byte payload + 0x00 delimiter",
+          ch2 == CH_DATA18 and len(p2) == 18 and f[-1] == 0x00 and 0x00 not in f[:-1],
+          f"ch={ch2} plen={len(p2)}")
+
+    # DATA18 uint24 LE encoding of channel 0 value = 0x012345 -> 45 23 01
+    f2 = make_data18([0x012345, 0, 0, 0, 0, 0])
+    _, p3 = unframe(f2[:-1])
+    check("DATA18 uint24 LE + 18-bit mask",
+          p3[0:3] == bytes([0x45, 0x23, 0x01]),
+          f"got {p3[0:3].hex()}")
+
+
+# ── Test 2: UDP loopback gating ──────────────────────────────────────────────
+async def test_udp() -> None:
+    print("Test 2: UDP relay -> mock serial, LIVE-gated")
+    mock = MockSerial()
+    link = SerialLink(transport=mock)
+    link.open()
+
+    class Gate:
+        live = False
+    gate = Gate()
+
+    relay = UdpRelay("127.0.0.1", 0, forward=link.write_raw, is_live=lambda: gate.live)
+    # bind to an ephemeral port
+    relay.port = _free_udp_port()
+    await relay.start()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    dgram = make_data18([10, 20, 30, 40, 50, 60])
+
+    # OFF/DEMO (not live): dropped
+    gate.live = False
+    sock.sendto(dgram, ("127.0.0.1", relay.port))
+    await asyncio.sleep(0.15)
+    check("datagram DROPPED when not LIVE", len(mock.written) == 0,
+          f"writes={len(mock.written)}")
+    check("relay stats show a drop", relay.stats.get("dropped", 0) == 1)
+
+    # LIVE: forwarded verbatim
+    gate.live = True
+    sock.sendto(dgram, ("127.0.0.1", relay.port))
+    await asyncio.sleep(0.15)
+    check("datagram FORWARDED when LIVE", len(mock.written) == 1)
+    check("forwarded bytes are VERBATIM (byte-parity)",
+          mock.written and mock.written[-1] == dgram,
+          f"got {mock.last_write.hex()}")
+
+    sock.close()
+    await relay.stop()
+    await link.stop()
+
+
+# ── Test 3: WS control against mock serial ──────────────────────────────────
+async def test_ws() -> None:
+    print("Test 3: WebSocket control API (mock serial)")
+    import websockets
+
+    mock = MockSerial()
+    link = SerialLink(transport=mock)
+    link.open()
+    link.start()
+
+    port = _free_tcp_port()
+    ctl = ControlAPI(link, host="127.0.0.1", ws_port=port, tcp_port=0)
+    link.on_frame(cobs.CH_TEL, ctl.on_tel)
+    link.on_frame(cobs.CH_LOG, ctl.on_log)
+    link.on_frame(cobs.CH_RESP, ctl.on_resp)
+    await ctl.start()
+
+    async with websockets.connect(f"ws://127.0.0.1:{port}") as ws:
+        hello = json.loads(await ws.recv())
+        check("server greets with hello", hello.get("type") == "hello"
+              and hello.get("api_version") == 1)
+        first_status = json.loads(await ws.recv())
+        check("initial status snapshot is OFF/gated",
+              first_status.get("event") == "status"
+              and first_status.get("source") == "OFF"
+              and first_status.get("motion_gated") is True)
+
+        # set_source LIVE
+        await ws.send(json.dumps({"verb": "set_source", "source": "LIVE", "id": 1}))
+        got_status_event = False
+        got_resp = False
+        # We expect a broadcast status event + a direct resp (order not fixed).
+        for _ in range(4):
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+            if msg.get("type") == "event" and msg.get("event") == "status" \
+                    and msg.get("source") == "LIVE":
+                got_status_event = True
+            if msg.get("type") == "resp" and msg.get("verb") == "set_source":
+                got_resp = True
+                check("set_source resp ok + id echoed",
+                      msg.get("ok") is True and msg.get("id") == 1)
+            if got_status_event and got_resp:
+                break
+        check("received LIVE status event", got_status_event)
+        check("received set_source resp", got_resp)
+        check("is_live() now true", ctl.is_live() is True)
+
+        # OFF must emit PLAY:STOP over serial (framed CMD)
+        mock.written.clear()
+        await ws.send(json.dumps({"verb": "set_source", "source": "OFF", "id": 2}))
+        await asyncio.sleep(0.2)
+        # decode what was written; expect a PLAY:STOP CMD frame present
+        cmds = _decode_cmd_frames(mock.written)
+        check("OFF sends PLAY:STOP over serial", "PLAY:STOP" in cmds, f"cmds={cmds}")
+        check("OFF sends SOURCE:OFF (forward-compat)", "SOURCE:OFF" in cmds,
+              f"cmds={cmds}")
+        check("is_live() false after OFF", ctl.is_live() is False)
+
+        # A device RESP frame fans out to the WS client
+        link.feed(frame(cobs.CH_RESP, b"MEM used=1 free=2"))
+        found_resp = False
+        for _ in range(5):
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=2))
+            if msg.get("event") == "resp" and "MEM used" in msg.get("text", ""):
+                found_resp = True
+                break
+        check("device RESP fans out to WS client", found_resp)
+
+    await ctl.stop()
+    await link.stop()
+
+
+# ── Test 4: line-JSON TCP control transport ─────────────────────────────────
+async def test_tcp() -> None:
+    print("Test 4: line-JSON TCP control API (mock serial)")
+    mock = MockSerial()
+    link = SerialLink(transport=mock)
+    link.open()
+    link.start()
+
+    port = _free_tcp_port()
+    ctl = ControlAPI(link, host="127.0.0.1", ws_port=0, tcp_port=port)
+    await ctl.start()
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+    async def recv_json():
+        line = await asyncio.wait_for(reader.readline(), timeout=2)
+        return json.loads(line.decode("utf-8").strip())
+
+    hello = await recv_json()
+    check("TCP: hello greeting (transport=tcp)",
+          hello.get("type") == "hello" and hello.get("transport") == "tcp")
+    status = await recv_json()
+    check("TCP: initial status snapshot OFF/gated",
+          status.get("event") == "status" and status.get("source") == "OFF")
+
+    # set_source LIVE via one JSON line
+    writer.write(json.dumps({"verb": "set_source", "source": "LIVE", "id": 7}).encode() + b"\n")
+    await writer.drain()
+    got_resp = False
+    got_live_event = False
+    for _ in range(4):
+        msg = await recv_json()
+        if msg.get("type") == "resp" and msg.get("verb") == "set_source":
+            got_resp = msg.get("ok") is True and msg.get("id") == 7
+        if msg.get("event") == "status" and msg.get("source") == "LIVE":
+            got_live_event = True
+        if got_resp and got_live_event:
+            break
+    check("TCP: set_source resp ok + id echoed", got_resp)
+    check("TCP: LIVE status event received", got_live_event)
+    check("TCP: is_live() true", ctl.is_live() is True)
+
+    writer.close()
+    await ctl.stop()
+    await link.stop()
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+def _decode_cmd_frames(chunks: list[bytes]) -> list[str]:
+    out: list[str] = []
+    for chunk in chunks:
+        # each chunk is a full frame ending in 0x00
+        body = chunk[:-1] if chunk and chunk[-1] == 0x00 else chunk
+        ch, payload = unframe(body)
+        if ch == CH_CMD:
+            out.append(payload.decode("ascii", "replace"))
+    return out
+
+
+def _free_tcp_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _free_udp_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+async def _async_main() -> None:
+    await test_udp()
+    await test_ws()
+    await test_tcp()
+
+
+def main() -> int:
+    print("=== HIL bridge self-test (no hardware) ===")
+    test_cobs()
+    asyncio.run(_async_main())
+    print()
+    if _failures:
+        print(f"RESULT: FAIL ({len(_failures)} check(s) failed: {_failures})")
+        return 1
+    print("RESULT: ALL GREEN")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bridge/serial_link.py
+++ b/bridge/serial_link.py
@@ -1,0 +1,199 @@
+"""serial_link.py — async COBS serial link to the ESP32 "mini".
+
+pyserial @921600. An async RX task splits the inbound byte stream on 0x00
+delimiters, COBS-decodes each frame, and routes CH_TEL / CH_LOG / CH_RESP to
+registered callbacks. TX helpers frame + write CH_DATA18 and CH_CMD.
+
+The serial device is OPTIONAL and MOCKABLE: pass ``device=None`` (or a device
+that fails to open with ``require_device=False``) and the link runs with a
+loopback-free null sink so the whole service and the self-tests run with NO
+hardware attached. You can also inject any object implementing the tiny
+``SerialTransport`` protocol (``write``/``read``/``close``) — the self-test
+uses a mock sink this way.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional, Protocol
+
+from cobs import (
+    CH_CMD, CH_DATA18, CH_LOG, CH_RESP, CH_TEL,
+    frame, make_cmd, make_data18, unframe,
+)
+
+log = logging.getLogger("bridge.serial")
+
+# channel -> callback(payload: bytes). Callbacks may be sync or async.
+FrameCallback = Callable[[bytes], "None | Awaitable[None]"]
+
+
+class SerialTransport(Protocol):
+    """Minimal duck-typed interface a backend must provide."""
+    def write(self, data: bytes) -> int: ...
+    def read(self, size: int) -> bytes: ...
+    def close(self) -> None: ...
+
+
+class MockSerial:
+    """A no-hardware serial backend. Captures everything written to it in
+    ``.written`` (a list of raw byte-chunks) and never produces RX data unless
+    you feed it via ``feed_rx``. Used by the service when no device is attached
+    and by the self-test as the sink to assert against."""
+
+    def __init__(self) -> None:
+        self.written: list[bytes] = []
+        self._rx = bytearray()
+        self._closed = False
+
+    def write(self, data: bytes) -> int:
+        self.written.append(bytes(data))
+        return len(data)
+
+    def read(self, size: int) -> bytes:
+        if not self._rx:
+            return b""
+        chunk = bytes(self._rx[:size])
+        del self._rx[:size]
+        return chunk
+
+    def feed_rx(self, data: bytes) -> None:
+        """Inject bytes as if the device had sent them (for tests)."""
+        self._rx += data
+
+    def close(self) -> None:
+        self._closed = True
+
+    # convenience for tests
+    @property
+    def last_write(self) -> bytes:
+        return self.written[-1] if self.written else b""
+
+
+class SerialLink:
+    def __init__(
+        self,
+        device: Optional[str] = None,
+        baud: int = 921600,
+        transport: Optional[SerialTransport] = None,
+        require_device: bool = False,
+        poll_interval: float = 0.002,
+    ) -> None:
+        self.device = device
+        self.baud = baud
+        self.poll_interval = poll_interval
+        self._transport: Optional[SerialTransport] = transport
+        self._require_device = require_device
+        self._callbacks: dict[int, FrameCallback] = {}
+        self._acc = bytearray()
+        self._rx_task: Optional[asyncio.Task] = None
+        self._stop = asyncio.Event()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self.is_mock = transport is not None and not isinstance(transport, str)
+
+    # ── lifecycle ───────────────────────────────────────────────────────
+    def open(self) -> None:
+        """Open the backing transport. If a transport was injected, use it. If
+        ``device`` is None, fall back to a MockSerial. A real open failure is
+        fatal only when ``require_device=True``; otherwise we degrade to a mock
+        so the service still runs (physical mini may be in use elsewhere)."""
+        if self._transport is not None:
+            log.info("serial: using injected transport (%s)", type(self._transport).__name__)
+            return
+        if self.device is None:
+            log.warning("serial: no device configured -> MockSerial (no hardware)")
+            self._transport = MockSerial()
+            self.is_mock = True
+            return
+        try:
+            import serial  # pyserial, imported lazily so tests need no dep
+            self._transport = serial.Serial(self.device, self.baud, timeout=0)
+            log.info("serial: opened %s @ %d", self.device, self.baud)
+        except Exception as exc:  # noqa: BLE001
+            if self._require_device:
+                raise
+            log.warning("serial: open %s failed (%s) -> MockSerial", self.device, exc)
+            self._transport = MockSerial()
+            self.is_mock = True
+
+    def start(self) -> None:
+        self._loop = asyncio.get_event_loop()
+        if self._transport is None:
+            self.open()
+        self._stop.clear()
+        self._rx_task = asyncio.ensure_future(self._rx_loop())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._rx_task:
+            self._rx_task.cancel()
+            try:
+                await self._rx_task
+            except asyncio.CancelledError:
+                pass
+        if self._transport is not None:
+            try:
+                self._transport.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    # ── callbacks ───────────────────────────────────────────────────────
+    def on_frame(self, channel: int, cb: FrameCallback) -> None:
+        self._callbacks[channel] = cb
+
+    # ── TX ──────────────────────────────────────────────────────────────
+    def write_raw(self, data: bytes) -> int:
+        """Write already-framed bytes straight to the UART (used by the UDP
+        relay to forward a verbatim COBS DATA18 frame)."""
+        if self._transport is None:
+            return 0
+        try:
+            return self._transport.write(data)
+        except Exception as exc:  # noqa: BLE001
+            log.error("serial: write failed: %s", exc)
+            return 0
+
+    def send_data18(self, raw6) -> int:
+        return self.write_raw(make_data18(raw6))
+
+    def send_cmd(self, cmd: str) -> int:
+        log.debug("serial TX CMD: %s", cmd)
+        return self.write_raw(make_cmd(cmd))
+
+    # ── RX ──────────────────────────────────────────────────────────────
+    async def _rx_loop(self) -> None:
+        while not self._stop.is_set():
+            data = b""
+            if self._transport is not None:
+                try:
+                    data = self._transport.read(256)
+                except Exception as exc:  # noqa: BLE001
+                    log.error("serial: read failed: %s", exc)
+                    data = b""
+            if data:
+                self.feed(data)
+            else:
+                await asyncio.sleep(self.poll_interval)
+
+    def feed(self, data: bytes) -> None:
+        """Push received bytes through the delimiter splitter + decoder. Public
+        so tests can drive the RX path without a real port."""
+        for b in data:
+            if b == 0x00:
+                if self._acc:
+                    self._dispatch(bytes(self._acc))
+                self._acc.clear()
+            else:
+                self._acc.append(b)
+
+    def _dispatch(self, encoded: bytes) -> None:
+        ch, payload = unframe(encoded)
+        if ch is None:
+            log.debug("serial: dropped undecodable frame (%d bytes)", len(encoded))
+            return
+        cb = self._callbacks.get(ch)
+        if cb is None:
+            return
+        result = cb(payload)
+        if asyncio.iscoroutine(result):
+            asyncio.ensure_future(result)

--- a/bridge/test_client.py
+++ b/bridge/test_client.py
@@ -1,0 +1,89 @@
+"""test_client.py — local demo client for the HIL bridge.
+
+Drives the bridge the way the app / Android client will: opens a WS control
+connection, flips the source, and streams a few UDP motion frames. Prints every
+WS event it receives. Requires a running bridge (default: localhost) — start one
+first with:  python bridge.py   (no hardware needed; it uses a MockSerial).
+
+Usage:
+  python test_client.py [--host HOST] [--ws-port 8788] [--udp-port 8767]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import socket
+
+import websockets
+
+from cobs import make_data18
+
+
+async def listen(ws) -> None:
+    try:
+        async for raw in ws:
+            msg = json.loads(raw)
+            print(f"  <-- {msg.get('type','?'):6} {msg.get('event') or msg.get('verb') or ''} "
+                  f"{ {k: v for k, v in msg.items() if k not in ('type','event','verb')} }")
+    except websockets.ConnectionClosed:
+        pass
+
+
+async def send(ws, verb: str, **kw) -> None:
+    payload = {"verb": verb, **kw}
+    print(f"  --> {payload}")
+    await ws.send(json.dumps(payload))
+    await asyncio.sleep(0.3)
+
+
+def stream_motion(host: str, udp_port: int, n: int = 100) -> None:
+    """Send n DATA18 motion frames (a gentle heave sine) as UDP datagrams."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    mid = 0x1FFFF  # midpoint of 18-bit range
+    amp = 0x08000
+    for i in range(n):
+        z = int(mid + amp * math.sin(i * 0.15))
+        frame = make_data18([mid, mid, z, mid, mid, mid])
+        sock.sendto(frame, (host, udp_port))
+    sock.close()
+    print(f"  sent {n} UDP motion frames to {host}:{udp_port}")
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--ws-port", type=int, default=8788)
+    ap.add_argument("--udp-port", type=int, default=8767)
+    args = ap.parse_args()
+
+    uri = f"ws://{args.host}:{args.ws_port}"
+    print(f"connecting {uri}")
+    async with websockets.connect(uri) as ws:
+        listener = asyncio.ensure_future(listen(ws))
+        await asyncio.sleep(0.3)
+
+        await send(ws, "status")
+        await send(ws, "set_source", source="OFF")
+        await send(ws, "set_source", source="DEMO")
+        await send(ws, "play", action="stop")
+
+        print("-- switching to LIVE + streaming motion --")
+        await send(ws, "set_source", source="LIVE")
+        stream_motion(args.host, args.udp_port, n=100)
+        await asyncio.sleep(0.5)
+
+        await send(ws, "mem")
+        await send(ws, "list_files")
+        await send(ws, "select_demo", name="nurburgring_lap1")
+        await send(ws, "boot_source", source="OFF")
+        await send(ws, "set_source", source="OFF")
+
+        await asyncio.sleep(0.5)
+        listener.cancel()
+    print("done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bridge/udp_relay.py
+++ b/bridge/udp_relay.py
@@ -1,0 +1,71 @@
+"""udp_relay.py — low-latency UDP -> serial motion relay.
+
+Binds an asyncio UDP endpoint. Each received datagram body is a VERBATIM COBS
+CH_DATA18 frame produced by the app (identical bytes to what the app would have
+written to a direct serial link — see app/src/serial_port.cpp sendCobsData).
+The relay forwards that datagram straight to the serial UART, unmodified,
+fire-and-forget.
+
+Gating: frames are forwarded ONLY while the current source is LIVE. In OFF/DEMO
+they are silently dropped. The relay asks a caller-supplied predicate
+``is_live()`` on every datagram so the control API's state machine stays the
+single source of truth.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable
+
+log = logging.getLogger("bridge.udp")
+
+
+class UdpRelayProtocol(asyncio.DatagramProtocol):
+    def __init__(self, forward: Callable[[bytes], int], is_live: Callable[[], bool],
+                 stats: dict) -> None:
+        self._forward = forward
+        self._is_live = is_live
+        self._stats = stats
+        self.transport: asyncio.DatagramTransport | None = None
+
+    def connection_made(self, transport) -> None:  # type: ignore[override]
+        self.transport = transport
+        sock = transport.get_extra_info("sockname")
+        log.info("udp: listening on %s", sock)
+
+    def datagram_received(self, data: bytes, addr) -> None:  # type: ignore[override]
+        self._stats["rx"] = self._stats.get("rx", 0) + 1
+        if not self._is_live():
+            self._stats["dropped"] = self._stats.get("dropped", 0) + 1
+            return
+        # Verbatim forward — do NOT re-encode; the datagram already IS a full
+        # COBS DATA18 frame (…encoded bytes… + 0x00 delimiter).
+        self._forward(data)
+        self._stats["forwarded"] = self._stats.get("forwarded", 0) + 1
+
+    def error_received(self, exc) -> None:  # type: ignore[override]
+        log.warning("udp: error_received: %s", exc)
+
+
+class UdpRelay:
+    def __init__(self, host: str, port: int,
+                 forward: Callable[[bytes], int],
+                 is_live: Callable[[], bool]) -> None:
+        self.host = host
+        self.port = port
+        self._forward = forward
+        self._is_live = is_live
+        self.stats: dict = {"rx": 0, "forwarded": 0, "dropped": 0}
+        self._transport: asyncio.DatagramTransport | None = None
+
+    async def start(self) -> None:
+        loop = asyncio.get_event_loop()
+        self._transport, _ = await loop.create_datagram_endpoint(
+            lambda: UdpRelayProtocol(self._forward, self._is_live, self.stats),
+            local_addr=(self.host, self.port),
+        )
+
+    async def stop(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None


### PR DESCRIPTION
**Draft / WIP** — Phase-1 of the HIL network bridge (see `6dof/HIL_BRIDGE.md` + `6dof/DECISIONS.md`). Voron-side Python service that relays app motion over the network to the mini and exposes a control API. **Not yet hardware-validated on the rig** (next step: deploy to the Voron, drive UDP motion, watch the Cobra move on camera).

## What's here (`bridge/`, Python 3 + asyncio, 12 files)
- **`cobs.py`** — COBS codec + channel framing, byte-parity with `Controller/include/cobs.h`; channels incl. new `CH_DATA_RAW=0x07`. `make_data_raw()` = 6×float32 LE.
- **`serial_link.py`** — async pyserial @921600; RX splits on 0x00 → routes TEL/LOG/RESP; **mockable** (no real port opened in tests).
- **`udp_relay.py`** — forwards each datagram verbatim to the UART **only when source==LIVE** (drops+counts otherwise).
- **`control_api.py`** — **dual WebSocket + line-JSON TCP** control (one shared schema/dispatch), OFF/DEMO/LIVE state machine, device-frame + status fan-out. Optional shared-token auth seam (disabled by default = trusted-LAN parity).
- **`bridge.py`** — asyncio entrypoint, argparse/env config, graceful shutdown.
- **`hil_bridge.service` + `install.sh`** — one-command Voron systemd install (the 'create service' action).
- **`PROTOCOL.md`, `README.md`, `requirements.txt`, `test_client.py`, `selftest.py`.**

## Locked decisions applied
- **LIVE = raw telemetry, ESP-cued** — relay forwards verbatim, never cues.
- **Raw = 6×float32** on `CH_DATA_RAW=0x07` (baked stays 0x06); `.m6p` v2 float32.
- **OFF (and startup) HOMES** — sends `PLAY:STOP`→`ZERO` today (+`SOURCE:OFF` forward-compat until Phase-3 firmware homes internally).
- **Ports** UDP 8767 / WS 8788 / TCP 8789 (configurable).

## Verification
`bridge/selftest.py` — **33 checks, all green** (COBS parity incl. zero-runs/>254B, DATA18 + DATA_RAW float32 round-trip, UDP LIVE-gating verbatim-forward, WS+TCP state machine → serial commands → device RESP fan-out, full auth handshake). Hardware-free (mock serial). Smoke-tested `bridge.py` end-to-end with `test_client.py`.

## Not yet
Real-rig validation; app-side UdpTransport + control client (Phase 2); firmware SOURCE modes + on-ESP cue engine (Phase 3). Depends on none of those to run standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)