### PR TITLE
feat(app): Phase 2 — network HIL transport + source/demo UI + raw-HIL TX

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -101,6 +101,7 @@ add_executable(stewart-platform WIN32
     src/ui_panels.cpp
     src/platform_viz.cpp
     src/serial_port.cpp
+    src/udp_transport.cpp
     src/plugin_manager.cpp
     src/test_harness_panel.cpp
     src/control_server.cpp

--- a/app/src/app.cpp
+++ b/app/src/app.cpp
@@ -163,11 +163,19 @@ void App::hilTxLoop() {
             double now = now_sec();
             if (now - last_send[ei] >= interval) {
                 last_send[ei] = now;
-                // Always use hil_tx_raw from the main pipeline — this includes
-                // MCA dynamics, tilt coordination, intensity, and axis gain.
-                uint32_t raw[6];
-                memcpy(raw, e.hil_tx_raw, sizeof(raw));
-                e.serial->sendCobsData(raw, e.config.bit_depth);
+                if (e.hil_raw_mode && e.hil_cap_raw) {
+                    // RAW HIL: stream pre-cueing input_pct (app axis order, no swap).
+                    // The ESP runs the single cue engine and swaps axes after cueing.
+                    float f[6];
+                    memcpy(f, e.hil_tx_raw_f, sizeof(f));
+                    e.serial->sendCobsDataRaw(f);
+                } else {
+                    // BAKED: hil_tx_raw already carries MCA dynamics, tilt
+                    // coordination, intensity, axis gain, and the surge<->sway swap.
+                    uint32_t raw[6];
+                    memcpy(raw, e.hil_tx_raw, sizeof(raw));
+                    e.serial->sendCobsData(raw, e.config.bit_depth);
+                }
             }
             ei++;
         }
@@ -257,6 +265,12 @@ static void saveEntityToJSON(cJSON* ej, const Entity& e) {
         cJSON_AddNumberToObject(hil, "tx_hz", e.hil_tx_hz);
         cJSON_AddNumberToObject(hil, "tick_rate_us", e.hil_tick_rate_us);
         cJSON_AddBoolToObject(hil, "auto_connect", e.hil_auto_connect);
+        // Network bridge transport
+        cJSON_AddBoolToObject(hil, "network", e.hil_network);
+        cJSON_AddStringToObject(hil, "host", e.hil_host);
+        cJSON_AddNumberToObject(hil, "udp_port", e.hil_udp_port);
+        cJSON_AddNumberToObject(hil, "tcp_port", e.hil_tcp_port);
+        cJSON_AddBoolToObject(hil, "raw_mode", e.hil_raw_mode);
         if (e.hil_fingerprint[0] != '\0')
             cJSON_AddStringToObject(hil, "fingerprint", e.hil_fingerprint);
     }
@@ -401,6 +415,11 @@ static void loadEntityFromJSON(Entity& e, cJSON* ej) {
             if (v >= 4 && v <= 100) e.hil_tick_rate_us = v;
         }
         if ((val = cJSON_GetObjectItem(hil, "auto_connect"))) e.hil_auto_connect = cJSON_IsTrue(val);
+        if ((val = cJSON_GetObjectItem(hil, "network"))) e.hil_network = cJSON_IsTrue(val);
+        if ((val = cJSON_GetObjectItem(hil, "host")) && cJSON_IsString(val)) snprintf(e.hil_host, sizeof(e.hil_host), "%s", val->valuestring);
+        if ((val = cJSON_GetObjectItem(hil, "udp_port"))) e.hil_udp_port = val->valueint;
+        if ((val = cJSON_GetObjectItem(hil, "tcp_port"))) e.hil_tcp_port = val->valueint;
+        if ((val = cJSON_GetObjectItem(hil, "raw_mode"))) e.hil_raw_mode = cJSON_IsTrue(val);
         if ((val = cJSON_GetObjectItem(hil, "fingerprint"))) snprintf(e.hil_fingerprint, sizeof(e.hil_fingerprint), "%s", val->valuestring);
     }
 }
@@ -585,6 +604,13 @@ Entity& App::addEntity(const char* name, EntityType type) {
     e.hil_baud = 921600;
     e.hil_auto_connect = true;
     e.hil_last_reconnect = 0.0;
+    memset(e.hil_tx_raw_f, 0, sizeof(e.hil_tx_raw_f));
+    e.hil_network = false;
+    snprintf(e.hil_host, sizeof(e.hil_host), "%s", "192.168.1.168");  // Voron default
+    e.hil_udp_port = 8767;
+    e.hil_tcp_port = 8789;
+    e.hil_cap_raw = false;
+    e.hil_raw_mode = false;
     memset(e.hil_fingerprint, 0, sizeof(e.hil_fingerprint));
     memset(e.hil_fw_version, 0, sizeof(e.hil_fw_version));
     e.hil_proto_ver = 0;
@@ -910,6 +936,18 @@ void App::handleHilLine(int entity_id, const char* line) {
         // Also store in legacy fields for UI/save compat
         snprintf(e->hil_fw_version, sizeof(e->hil_fw_version), "%s", fw);
         e->hil_proto_ver = proto;
+
+        // Raw-HIL capability gate: newer firmware advertises "rawhil=1" or a
+        // caps token containing "raw" (e.g. caps=raw). Old firmware omits it →
+        // hil_cap_raw stays false → baked path unchanged.
+        {
+            bool cap = false;
+            if (strstr(payload, "rawhil=1")) cap = true;
+            else { const char* caps = strstr(payload, "caps=");
+                   if (caps && strstr(caps, "raw")) cap = true; }
+            e->hil_cap_raw = cap;
+            if (!cap) e->hil_raw_mode = false;  // can't stream raw to a baked-only device
+        }
 
         // Fingerprint verification — ONLY advance handshake during WaitFingerprint.
         // Stale FINGERPRINT responses (from manual button clicks or previous sessions)
@@ -2173,8 +2211,10 @@ skip_input_processing:
                 e.serial.reset();
                 e.transport.usb_connected = false;
             }
-            // Auto-reconnect: retry every 3 seconds if auto_connect is enabled
-            if (!e.serial && e.hil_auto_connect
+            // Auto-reconnect: retry every 3 seconds if auto_connect is enabled.
+            // Serial-only — the network transport is (re)built from the device
+            // card's Network Connect button, not auto-enumerated here.
+            if (!e.hil_network && !e.serial && e.hil_auto_connect
                 && frame_time - e.hil_last_reconnect >= 3.0) {
                 e.hil_last_reconnect = frame_time;
 
@@ -2339,6 +2379,12 @@ skip_input_processing:
                     }
                     { uint32_t tmp = raw[0]; raw[0] = raw[1]; raw[1] = tmp; }
                     memcpy(e.hil_tx_raw, raw, sizeof(raw));
+
+                    // RAW-HIL snapshot: pre-cueing input_pct in app axis order
+                    // (surge=0, sway=1), NO swap — the ESP cues then swaps.
+                    // Baked applies MCA/intensity/gain here; raw ships the input
+                    // untouched so the device's single cue engine owns the feel.
+                    memcpy(e.hil_tx_raw_f, e.state.input_pct, sizeof(e.hil_tx_raw_f));
                 }
 
                 // Retry TELRATE if telemetry isn't flowing after handshake
@@ -2441,6 +2487,11 @@ skip_input_processing:
         static int    s_hil_baud[8] = {};
         static int    s_hil_tx_hz[8] = {};
         static bool   s_hil_auto[8] = {};
+        static bool   s_hil_net[8] = {};
+        static char   s_hil_host[8][64] = {};
+        static int    s_hil_udp[8] = {};
+        static int    s_hil_tcp[8] = {};
+        static bool   s_hil_raw[8] = {};
         static int    s_dyn_id = -1;
         static bool   s_inited = false;
 
@@ -2464,6 +2515,11 @@ skip_input_processing:
                     if (s_hil_baud[ei] != entities[ei].hil_baud) return false;
                     if (s_hil_tx_hz[ei] != entities[ei].hil_tx_hz) return false;
                     if (s_hil_auto[ei] != entities[ei].hil_auto_connect) return false;
+                    if (s_hil_net[ei] != entities[ei].hil_network) return false;
+                    if (strcmp(s_hil_host[ei], entities[ei].hil_host) != 0) return false;
+                    if (s_hil_udp[ei] != entities[ei].hil_udp_port) return false;
+                    if (s_hil_tcp[ei] != entities[ei].hil_tcp_port) return false;
+                    if (s_hil_raw[ei] != entities[ei].hil_raw_mode) return false;
                 }
             }
             return true;
@@ -2489,6 +2545,11 @@ skip_input_processing:
                     s_hil_baud[ei] = entities[ei].hil_baud;
                     s_hil_tx_hz[ei] = entities[ei].hil_tx_hz;
                     s_hil_auto[ei] = entities[ei].hil_auto_connect;
+                    s_hil_net[ei] = entities[ei].hil_network;
+                    snprintf(s_hil_host[ei], sizeof(s_hil_host[ei]), "%s", entities[ei].hil_host);
+                    s_hil_udp[ei] = entities[ei].hil_udp_port;
+                    s_hil_tcp[ei] = entities[ei].hil_tcp_port;
+                    s_hil_raw[ei] = entities[ei].hil_raw_mode;
                 }
             }
         };

--- a/app/src/app.h
+++ b/app/src/app.h
@@ -24,7 +24,7 @@ static const int INPUT_HISTORY_LEN = 2048;  // ~10s at 200Hz
 #include "plugin_manager.h"
 
 // Forward declaration
-class SerialPort;
+class ITransport;   // SerialPort or UdpTransport (see transport.h)
 
 // ── Platform Types ──────────────────────────────────────────────────
 
@@ -182,8 +182,8 @@ struct Entity {
     float           rate_tx_hz;
     float           rate_tel_hz;
 
-    // HIL: serial connection to ESP32
-    std::shared_ptr<SerialPort> serial;  // nullptr for SIL entities
+    // HIL: transport to the ESP32 — SerialPort (USB) or UdpTransport (network bridge)
+    std::shared_ptr<ITransport> serial;  // nullptr for SIL entities
     int             hil_tx_hz;           // target motion packet send rate
     double          hil_last_tx_time;    // last binary packet send time
     int             hil_tel_seq;         // last processed telemetry seq
@@ -200,7 +200,18 @@ struct Entity {
     int             hil_baud;            // serial baud rate (saved per-device)
     bool            hil_auto_connect;    // try to reconnect if disconnected
     double          hil_last_reconnect;  // last reconnect attempt time
-    uint32_t        hil_tx_raw[6];       // latest raw packet for background TX thread (up to 18-bit)
+    uint32_t        hil_tx_raw[6];       // latest baked packet for background TX thread (up to 18-bit)
+    float           hil_tx_raw_f[6];     // latest RAW (pre-cueing) input_pct snapshot for CH_DATA_RAW
+
+    // Network HIL transport (Voron bridge). When hil_network, `serial` is a UdpTransport.
+    bool            hil_network;         // true = network bridge transport, false = USB serial
+    char            hil_host[64];        // bridge host (IP or hostname)
+    int             hil_udp_port;        // bridge UDP motion port (default 8767)
+    int             hil_tcp_port;        // bridge line-JSON TCP control port (default 8789)
+
+    // Raw-HIL streaming (CH_DATA_RAW). Gated on device capability + user toggle.
+    bool            hil_cap_raw;         // device advertises raw-HIL (fingerprint caps=raw / network)
+    bool            hil_raw_mode;        // user: stream pre-cueing raw telemetry (ESP cues) vs baked
 
     // Device fingerprint / handshake
     char            hil_fingerprint[16]; // stored MAC fingerprint (12 hex chars + NUL)

--- a/app/src/cobs.h
+++ b/app/src/cobs.h
@@ -12,6 +12,8 @@
 #define COBS_CH_LOG    0x04  // ESP->App: log/debug text
 #define COBS_CH_RESP   0x05  // ESP->App: command response text
 #define COBS_CH_DATA18 0x06  // App->ESP: motion data (18 bytes: 6x uint24 LE, low 18 bits used)
+#define COBS_CH_DATA_RAW 0x07 // App->ESP: RAW motion telemetry (24 bytes: 6x float32 LE, pre-cueing,
+                              //           app axis order surge=0/sway=1 — device cues + swaps)
 
 // Max COBS overhead: 1 byte per 254 input bytes + 1
 #define COBS_MAX_ENC_SIZE(n) ((n) + ((n) / 254) + 1)

--- a/app/src/control_server.cpp
+++ b/app/src/control_server.cpp
@@ -619,8 +619,65 @@ std::string handle(const std::string& line) {
         double pre = num(a, "preroll_s", 5.0);
         int loop_point = (int)num(a, "loop_point", 0);
         const char* path = strarg(a, "path", "sequence.m6p");
+        bool raw = boolarg(a, "raw", false);   // M6P2 float32 raw (pre-cueing) export
         if (!e) { ERR("no entity"); }
         else if (idx < 0) { ERR("no recording"); }
+        else if (raw) {
+            // ── M6P2 RAW export: 6x float32 LE, PRE-cueing, app axis order (no swap).
+            // The device runs the single cue engine at playback, so this is the
+            // lossless master (change-list (a) / DECISIONS round 3 float32 decision).
+            const SavedRecording& sr = g_app.saved_recordings[idx];
+            double dur = sr.samples.empty() ? 0.0 : sr.samples.back().time;
+            int count = (int)(dur * rate) + 1;
+            std::vector<uint8_t> data((size_t)count * 6 * 4);
+            BakeStats st; for (int i = 0; i < 6; i++) { st.mn[i] = 1e9f; st.mx[i] = -1e9f; st.sat[i] = 0; }
+            for (int k = 0; k < count; k++) {
+                float pct[6]; interp_recording(sr, (double)k / rate, pct);
+                for (int i = 0; i < 6; i++) {
+                    if (pct[i] < st.mn[i]) st.mn[i] = pct[i];
+                    if (pct[i] > st.mx[i]) st.mx[i] = pct[i];
+                    if (pct[i] > 100.0f || pct[i] < -100.0f) st.sat[i] += 1.0;
+                    uint32_t bitsLE; memcpy(&bitsLE, &pct[i], 4);   // host LE
+                    uint8_t* d = &data[((size_t)k * 6 + i) * 4];
+                    d[0] = (uint8_t)(bitsLE & 0xFF);       d[1] = (uint8_t)((bitsLE >> 8) & 0xFF);
+                    d[2] = (uint8_t)((bitsLE >> 16) & 0xFF); d[3] = (uint8_t)((bitsLE >> 24) & 0xFF);
+                }
+            }
+            st.n = count;
+            for (int i = 0; i < 6; i++) st.sat[i] = count ? st.sat[i] / count * 100.0 : 0.0;
+            uint32_t crc = crc32_buf(data.data(), data.size());
+            uint8_t hdr[64] = {0};
+            memcpy(hdr, "M6P2", 4);
+            uint16_t ver = 2, r16 = (uint16_t)rate;
+            memcpy(hdr + 4, &ver, 2);
+            memcpy(hdr + 6, &r16, 2);
+            uint32_t c32 = (uint32_t)count, lp = (uint32_t)loop_point;
+            memcpy(hdr + 8,  &c32, 4);
+            memcpy(hdr + 12, &lp, 4);
+            const char* nm = g_app.saved_recordings[idx].name;
+            strncpy((char*)hdr + 16, nm, 31);
+            hdr[48] = 1;   // format: 1 = float32 (6 channels)
+            hdr[49] = 6;   // channel count
+            memcpy(hdr + 52, &crc, 4);
+            FILE* f = fopen(path, "wb");
+            if (!f) ERR("cannot open output path");
+            else {
+                fwrite(hdr, 1, 64, f);
+                fwrite(data.data(), 1, data.size(), f);
+                fclose(f);
+                cJSON* r = stats_json(st, rate);
+                cJSON_AddStringToObject(r, "path", path);
+                cJSON_AddStringToObject(r, "format", "M6P2-float32");
+                cJSON_AddNumberToObject(r, "bytes", (double)(64 + data.size()));
+                cJSON_AddNumberToObject(r, "loop_point", loop_point);
+                char crchex[16]; snprintf(crchex, sizeof(crchex), "%08X", crc);
+                cJSON_AddStringToObject(r, "crc32", crchex);
+                cJSON_AddStringToObject(r, "name", nm);
+                g_app.log(-1, "system", "Exported RAW %s (%d samples @ %dHz float32, %u B)",
+                          path, count, rate, (unsigned)(64 + data.size()));
+                RESULT(r);
+            }
+        }
         else {
             std::vector<uint16_t> seq; BakeStats st;
             if (!bake_sequence(idx, *e, rate, bits, pre, seq, st)) ERR("bake failed");

--- a/app/src/serial_port.cpp
+++ b/app/src/serial_port.cpp
@@ -269,6 +269,19 @@ bool SerialPort::sendCobsData(const uint32_t raw[6], int bit_depth) {
     return write(enc, enc_len);
 }
 
+bool SerialPort::sendCobsDataRaw(const float raw[6]) {
+    // Frame: [CH_DATA_RAW] + [6 x float32 LE] = 25 bytes raw.
+    // RAW = pre-cueing telemetry in app axis order (surge=0, sway=1); the ESP
+    // runs the cue engine and swaps axes after cueing. No swap on the wire.
+    uint8_t frame[1 + 24];
+    frame[0] = COBS_CH_DATA_RAW;
+    memcpy(frame + 1, raw, 24);  // 6 x float32 LE (host is LE on x86/ARM targets)
+    uint8_t enc[64];
+    int enc_len = cobs_encode(frame, sizeof(frame), enc);
+    enc[enc_len++] = 0x00;  // delimiter
+    return write(enc, enc_len);
+}
+
 bool SerialPort::sendCobsCommand(const char* cmd) {
     if (!m_open.load()) return false;
     int slen = (int)strlen(cmd);

--- a/app/src/serial_port.h
+++ b/app/src/serial_port.h
@@ -19,14 +19,7 @@
 
 #include "dev_log.h"
 #include "cobs.h"
-
-// Parsed telemetry from ESP32
-struct ESP32Telemetry {
-    float angles[6];     // servo angles (radians) from ESP32 IK
-    float positions[6];  // input positions (arr[] on ESP32)
-    double timestamp;    // local time when received
-    int seq;             // increments on each new TEL line
-};
+#include "transport.h"   // ITransport + ESP32Telemetry
 
 // A detected COM port
 struct ComPortInfo {
@@ -34,7 +27,7 @@ struct ComPortInfo {
     std::string desc;    // e.g. "USB Serial Device (COM3)"
 };
 
-class SerialPort {
+class SerialPort : public ITransport {
 public:
     SerialPort();
     ~SerialPort();
@@ -44,35 +37,47 @@ public:
 
     // Open/close
     bool open(const char* port, int baud = 115200);
-    void close();
-    bool isOpen() const { return m_open.load(); }
+    void close() override;
+    bool isOpen() const override { return m_open.load(); }
 
     // Write raw bytes
-    bool write(const uint8_t* data, int len);
+    bool write(const uint8_t* data, int len) override;
 
     // Send a text command.
     // COBS mode: sent on CH_CMD frame. Fallback mode: appends 'X' terminator.
-    bool sendCommand(const char* cmd);
+    bool sendCommand(const char* cmd) override;
 
     // COBS-framed motion send — always uses CH_DATA18 (18-byte 6x uint24 LE).
     // Values are masked to 18 bits on the wire regardless of configured bit depth.
-    bool sendCobsData(const uint32_t raw[6], int bit_depth);
-    bool sendCobsCommand(const char* cmd);        // string command on CH_CMD
+    bool sendCobsData(const uint32_t raw[6], int bit_depth) override;
+    // RAW motion send — CH_DATA_RAW (24-byte 6x float32 LE, pre-cueing).
+    bool sendCobsDataRaw(const float raw[6]) override;
+    bool sendCobsCommand(const char* cmd) override;   // string command on CH_CMD
 
     // Enable COBS framing mode (binary protocol uses this)
-    void setCobsMode(bool v) { m_cobs_mode = v; }
-    bool isCobsMode() const  { return m_cobs_mode; }
+    void setCobsMode(bool v) override { m_cobs_mode = v; }
+    bool isCobsMode() const  override { return m_cobs_mode; }
 
     // Latest telemetry (thread-safe read)
-    ESP32Telemetry getLatestTelemetry() const;
+    ESP32Telemetry getLatestTelemetry() const override;
 
     // Connection info
-    const char* portName() const { return m_port_name; }
-    int rxBytes() const { return m_rx_bytes.load(); }
-    int txBytes() const { return m_tx_bytes.load(); }
-    int telemetrySeq() const { return m_telemetry.seq; }
-    float telemetryRate() const { return m_tel_rate.load(); }
-    int telemetryRejected() const { return m_tel_rejected.load(); }
+    const char* portName() const override { return m_port_name; }
+    int rxBytes() const override { return m_rx_bytes.load(); }
+    int txBytes() const override { return m_tx_bytes.load(); }
+    int telemetrySeq() const override { return m_telemetry.seq; }
+    float telemetryRate() const override { return m_tel_rate.load(); }
+    int telemetryRejected() const override { return m_tel_rejected.load(); }
+
+    // COBS decode counters (device card diagnostics)
+    int cobsDelimiters() const override { return m_cobs_delimiters.load(); }
+    int cobsDecodeOk()   const override { return m_cobs_decode_ok.load(); }
+    int cobsDecodeFail() const override { return m_cobs_decode_fail.load(); }
+    int cobsTel()  const override { return m_cobs_tel.load(); }
+    int cobsResp() const override { return m_cobs_resp.load(); }
+    int cobsLog()  const override { return m_cobs_log.load(); }
+
+    Kind kind() const override { return Kind::Serial; }
 
     // Line callback (optional — for logging raw lines to console)
     using LineCallback = std::function<void(const char* line)>;
@@ -84,7 +89,7 @@ public:
 
     // Thread-safe line queue: reader thread pushes, main thread drains.
     // This replaces direct callback invocation to avoid data races.
-    std::vector<std::string> drainLines();
+    std::vector<std::string> drainLines() override;
 
 private:
     void readerThread();
@@ -127,14 +132,13 @@ private:
 
     // COBS mode
     bool m_cobs_mode = false;
-public:
+    // COBS decode counters — private; exposed via cobs*() accessors (ITransport).
     std::atomic<int> m_cobs_delimiters{0};  // 0x00 bytes seen
     std::atomic<int> m_cobs_decode_ok{0};   // successful decodes
     std::atomic<int> m_cobs_decode_fail{0}; // failed decodes
     std::atomic<int> m_cobs_tel{0};         // TEL frames
     std::atomic<int> m_cobs_resp{0};        // RESP frames
     std::atomic<int> m_cobs_log{0};         // LOG frames
-private:
     uint8_t m_cobs_acc[512];  // COBS accumulation buffer
     int m_cobs_pos = 0;
     void processCobsFrame(const uint8_t *data, int len);

--- a/app/src/transport.h
+++ b/app/src/transport.h
@@ -1,0 +1,75 @@
+#pragma once
+/*
+ * ITransport — abstract HIL transport interface.
+ *
+ * A HIL "device" (Entity::serial) is reached over one of two transports:
+ *   - SerialPort  : direct USB COBS to the ESP32 (kind() == Serial)
+ *   - UdpTransport: UDP motion + line-JSON TCP control to the Voron bridge (kind() == Network)
+ *
+ * This is intentionally a SUPERSET interface (not a 5-method sketch): the HIL
+ * device card in ui_panels.cpp reads SerialPort-specific stats (byte counts,
+ * COBS decode counters, telemetry rate/seq/rejected), so every stat the UI
+ * touches is part of the contract. Both transports implement all of it; the
+ * network transport surfaces bridge-relayed equivalents.
+ *
+ * The wire format (COBS frames) is identical for both transports — only the
+ * carrier differs (WriteFile vs sendto()).
+ */
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Parsed telemetry from ESP32 (angles + input positions). Shared by all
+// transports; defined here so transport.h is the single owner.
+struct ESP32Telemetry {
+    float  angles[6];     // servo angles (radians) from ESP32 IK
+    float  positions[6];  // input positions (arr[] on ESP32)
+    double timestamp;     // local time when received
+    int    seq;           // increments on each new TEL frame
+};
+
+class ITransport {
+public:
+    enum class Kind { Serial, Network };
+
+    virtual ~ITransport() = default;
+
+    // ── Lifecycle ────────────────────────────────────────────────────
+    virtual bool isOpen() const = 0;
+    virtual void close() = 0;
+
+    // ── TX ───────────────────────────────────────────────────────────
+    virtual bool write(const uint8_t* data, int len) = 0;
+    virtual bool sendCommand(const char* cmd) = 0;
+    // BAKED motion (0x06): 6x uint24 LE, post-cueing servo-space (legacy path).
+    virtual bool sendCobsData(const uint32_t raw[6], int bit_depth) = 0;
+    // RAW motion (0x07): 6x float32 LE, PRE-cueing telemetry, app axis order.
+    virtual bool sendCobsDataRaw(const float raw[6]) = 0;
+    virtual bool sendCobsCommand(const char* cmd) = 0;
+
+    // ── RX ───────────────────────────────────────────────────────────
+    virtual std::vector<std::string> drainLines() = 0;
+    virtual ESP32Telemetry getLatestTelemetry() const = 0;
+
+    // ── Stats surfaced by the HIL device card ────────────────────────
+    virtual const char* portName() const = 0;
+    virtual int   rxBytes() const = 0;
+    virtual int   txBytes() const = 0;
+    virtual int   telemetrySeq() const = 0;
+    virtual float telemetryRate() const = 0;
+    virtual int   telemetryRejected() const = 0;
+
+    // ── COBS mode + decode counters (device card diagnostics) ────────
+    virtual void setCobsMode(bool v) = 0;
+    virtual bool isCobsMode() const = 0;
+    virtual int  cobsDelimiters() const = 0;  // 0x00 delimiters seen
+    virtual int  cobsDecodeOk() const = 0;     // successful decodes
+    virtual int  cobsDecodeFail() const = 0;   // failed decodes
+    virtual int  cobsTel() const = 0;          // CH_TEL frames
+    virtual int  cobsResp() const = 0;         // CH_RESP frames
+    virtual int  cobsLog() const = 0;          // CH_LOG frames
+
+    // ── Identity ─────────────────────────────────────────────────────
+    virtual Kind kind() const = 0;
+};

--- a/app/src/udp_transport.cpp
+++ b/app/src/udp_transport.cpp
@@ -1,0 +1,350 @@
+#include "udp_transport.h"
+
+#ifdef _WIN32
+#  define WIN32_LEAN_AND_MEAN
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#  pragma comment(lib, "ws2_32.lib")
+#endif
+
+#include "cobs.h"
+#include "cJSON.h"
+
+#include <cstring>
+#include <cstdio>
+#include <cstdint>
+#include <chrono>
+
+// ── helpers ─────────────────────────────────────────────────────────
+static double now_seconds() {
+    using namespace std::chrono;
+    return duration<double>(steady_clock::now().time_since_epoch()).count();
+}
+
+#ifdef _WIN32
+static const uintptr_t kInvalidSock = (uintptr_t)INVALID_SOCKET;
+#else
+static const uintptr_t kInvalidSock = ~(uintptr_t)0;
+#endif
+
+// ── Construction ────────────────────────────────────────────────────
+UdpTransport::UdpTransport(const char* host, int udp_port, int tcp_port)
+    : m_host(host ? host : ""), m_udp_port(udp_port), m_tcp_port(tcp_port) {
+    snprintf(m_name, sizeof(m_name), "%s:%d", m_host.c_str(), udp_port);
+    m_udp_sock = kInvalidSock;
+
+#ifdef _WIN32
+    // Resolve host once for the UDP motion datagrams.
+    char portstr[16];
+    snprintf(portstr, sizeof(portstr), "%d", udp_port);
+    addrinfo hints = {}; hints.ai_family = AF_INET; hints.ai_socktype = SOCK_DGRAM;
+    addrinfo* res = nullptr;
+    if (getaddrinfo(m_host.c_str(), portstr, &hints, &res) == 0 && res) {
+        SOCKET us = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        if (us != INVALID_SOCKET) {
+            m_udp_sock = (uintptr_t)us;
+            m_udp_addr = new sockaddr_storage();
+            memset(m_udp_addr, 0, sizeof(sockaddr_storage));
+            memcpy(m_udp_addr, res->ai_addr, res->ai_addrlen);
+            m_udp_addr_len = (int)res->ai_addrlen;
+            m_open.store(true);
+        }
+        freeaddrinfo(res);
+    }
+
+    // Best-effort non-blocking connect for the TCP control plane (<=1.5s).
+    {
+        char tportstr[16];
+        snprintf(tportstr, sizeof(tportstr), "%d", tcp_port);
+        addrinfo thints = {}; thints.ai_family = AF_INET; thints.ai_socktype = SOCK_STREAM;
+        addrinfo* tres = nullptr;
+        if (getaddrinfo(m_host.c_str(), tportstr, &thints, &tres) == 0 && tres) {
+            SOCKET cs = socket(tres->ai_family, tres->ai_socktype, tres->ai_protocol);
+            if (cs != INVALID_SOCKET) {
+                u_long nb = 1; ioctlsocket(cs, FIONBIO, &nb);
+                connect(cs, tres->ai_addr, (int)tres->ai_addrlen);
+                fd_set wf; FD_ZERO(&wf); FD_SET(cs, &wf);
+                timeval tv; tv.tv_sec = 1; tv.tv_usec = 500000;
+                bool ok = (select(0, nullptr, &wf, nullptr, &tv) > 0);
+                if (ok) {
+                    int err = 0; int elen = sizeof(err);
+                    getsockopt(cs, SOL_SOCKET, SO_ERROR, (char*)&err, &elen);
+                    ok = (err == 0);
+                }
+                u_long bl = 0; ioctlsocket(cs, FIONBIO, &bl);   // back to blocking
+                if (ok) {
+                    m_ctrl_sock.store((uintptr_t)cs);
+                    m_ctrl_connected.store(true);
+                    m_ctrl_stop.store(false);
+                    m_ctrl_reader = std::thread(&UdpTransport::ctrlReaderThread, this);
+                } else {
+                    closesocket(cs);
+                }
+            }
+            freeaddrinfo(tres);
+        }
+    }
+#endif
+}
+
+UdpTransport::~UdpTransport() {
+    close();
+    if (m_udp_addr) { delete (sockaddr_storage*)m_udp_addr; m_udp_addr = nullptr; }
+}
+
+void UdpTransport::close() {
+    m_open.store(false);
+    m_ctrl_stop.store(true);
+#ifdef _WIN32
+    uintptr_t cs = m_ctrl_sock.exchange(kInvalidSock);
+    if (cs != kInvalidSock) { shutdown((SOCKET)cs, SD_BOTH); closesocket((SOCKET)cs); }
+    if (m_ctrl_reader.joinable()) m_ctrl_reader.join();
+    m_ctrl_connected.store(false);
+    if (m_udp_sock != kInvalidSock) { closesocket((SOCKET)m_udp_sock); m_udp_sock = kInvalidSock; }
+#endif
+}
+
+// ── UDP motion plane ────────────────────────────────────────────────
+bool UdpTransport::write(const uint8_t* data, int len) {
+#ifdef _WIN32
+    if (m_udp_sock == kInvalidSock || !m_udp_addr) return false;
+    std::lock_guard<std::mutex> lk(m_udp_mutex);
+    int n = sendto((SOCKET)m_udp_sock, (const char*)data, len, 0,
+                   (sockaddr*)m_udp_addr, m_udp_addr_len);
+    if (n > 0) m_tx_bytes.fetch_add(n);
+    return n == len;
+#else
+    (void)data; (void)len; return false;
+#endif
+}
+
+bool UdpTransport::sendCobsData(const uint32_t raw[6], int bit_depth) {
+    (void)bit_depth;
+    uint8_t frame[1 + 18];
+    frame[0] = COBS_CH_DATA18;
+    for (int i = 0; i < 6; i++) {
+        uint32_t v = raw[i] & 0x3FFFFu;
+        frame[1 + i * 3]     = (uint8_t)(v & 0xFFu);
+        frame[1 + i * 3 + 1] = (uint8_t)((v >> 8) & 0xFFu);
+        frame[1 + i * 3 + 2] = (uint8_t)((v >> 16) & 0xFFu);
+    }
+    uint8_t enc[64];
+    int enc_len = cobs_encode(frame, sizeof(frame), enc);
+    enc[enc_len++] = 0x00;
+    return write(enc, enc_len);   // one datagram = one COBS frame
+}
+
+bool UdpTransport::sendCobsDataRaw(const float raw[6]) {
+    uint8_t frame[1 + 24];
+    frame[0] = COBS_CH_DATA_RAW;
+    memcpy(frame + 1, raw, 24);   // 6 x float32 LE, pre-cueing, app axis order
+    uint8_t enc[64];
+    int enc_len = cobs_encode(frame, sizeof(frame), enc);
+    enc[enc_len++] = 0x00;
+    return write(enc, enc_len);
+}
+
+bool UdpTransport::sendCommand(const char* cmd) {
+    return sendCobsCommand(cmd);
+}
+
+bool UdpTransport::sendCobsCommand(const char* cmd) {
+    // Forward-compat: emit a COBS CH_CMD frame as a UDP datagram. Today's bridge
+    // forwards motion datagrams to the UART only while LIVE; real control verbs
+    // travel over the TCP control plane (controlSend). Kept so app command paths
+    // (e.g. TELRATE) are functional if the bridge later passes CH_CMD through.
+    if (!cmd) return false;
+    int slen = (int)strlen(cmd);
+    if (slen <= 0 || slen > 254) return false;
+    uint8_t frame[256];
+    frame[0] = COBS_CH_CMD;
+    memcpy(frame + 1, cmd, slen);
+    uint8_t enc[300];
+    int enc_len = cobs_encode(frame, 1 + slen, enc);
+    enc[enc_len++] = 0x00;
+    return write(enc, enc_len);
+}
+
+// ── TCP control plane ───────────────────────────────────────────────
+bool UdpTransport::controlSend(const std::string& json_line) {
+#ifdef _WIN32
+    uintptr_t cs = m_ctrl_sock.load();
+    if (cs == kInvalidSock || !m_ctrl_connected.load()) return false;
+    std::string out = json_line;
+    if (out.empty() || out.back() != '\n') out.push_back('\n');
+    std::lock_guard<std::mutex> lk(m_ctrl_send_mutex);
+    int sent = 0, total = (int)out.size();
+    while (sent < total) {
+        int n = send((SOCKET)cs, out.data() + sent, total - sent, 0);
+        if (n <= 0) { m_ctrl_connected.store(false); return false; }
+        sent += n;
+    }
+    m_tx_bytes.fetch_add(total);
+    return true;
+#else
+    (void)json_line; return false;
+#endif
+}
+
+void UdpTransport::ctrlReaderThread() {
+#ifdef _WIN32
+    std::string buf;
+    char rx[2048];
+    while (!m_ctrl_stop.load()) {
+        uintptr_t cs = m_ctrl_sock.load();
+        if (cs == kInvalidSock) break;
+        int n = recv((SOCKET)cs, rx, sizeof(rx), 0);
+        if (n <= 0) break;
+        m_rx_bytes.fetch_add(n);
+        buf.append(rx, n);
+        size_t nl;
+        while ((nl = buf.find('\n')) != std::string::npos) {
+            std::string line = buf.substr(0, nl);
+            buf.erase(0, nl + 1);
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            if (!line.empty()) handleControlLine(line.c_str());
+        }
+    }
+    m_ctrl_connected.store(false);
+#endif
+}
+
+void UdpTransport::handleControlLine(const char* line) {
+    cJSON* root = cJSON_Parse(line);
+    if (!root) return;
+    m_ctrl_msgs.fetch_add(1);
+
+    const cJSON* type = cJSON_GetObjectItem(root, "type");
+    const char* ts = (type && cJSON_IsString(type)) ? type->valuestring : "";
+
+    if (strcmp(ts, "event") == 0) {
+        const cJSON* ev = cJSON_GetObjectItem(root, "event");
+        const char* es = (ev && cJSON_IsString(ev)) ? ev->valuestring : "";
+        if (strcmp(es, "status") == 0) {
+            parseStatusBody(root);
+        } else if (strcmp(es, "telemetry") == 0) {
+            m_cobs_tel.fetch_add(1);
+            const cJSON* hx = cJSON_GetObjectItem(root, "hex");
+            if (hx && cJSON_IsString(hx)) {
+                const char* h = hx->valuestring;
+                int hlen = (int)strlen(h);
+                uint8_t bytes[64]; int nb = 0;
+                for (int i = 0; i + 1 < hlen && nb < (int)sizeof(bytes); i += 2) {
+                    auto hv = [](char c)->int {
+                        if (c >= '0' && c <= '9') return c - '0';
+                        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+                        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+                        return 0;
+                    };
+                    bytes[nb++] = (uint8_t)((hv(h[i]) << 4) | hv(h[i + 1]));
+                }
+                if (nb >= 24) {
+                    float vals[12] = {};
+                    memcpy(vals, bytes, nb < 48 ? nb : 48);
+                    bool valid = true;
+                    for (int i = 0; i < 6; i++)
+                        if (vals[i] != vals[i] || vals[i] > 1e10f || vals[i] < -1e10f) { valid = false; break; }
+                    if (valid) {
+                        double t = now_seconds();
+                        {
+                            std::lock_guard<std::mutex> lk(m_tel_mutex);
+                            memcpy(m_telemetry.angles, vals, 6 * sizeof(float));
+                            if (nb >= 48) memcpy(m_telemetry.positions, vals + 6, 6 * sizeof(float));
+                            m_telemetry.timestamp = t;
+                            m_telemetry.seq++;
+                            m_tel_seq.store(m_telemetry.seq);
+                            m_tel_times[m_tel_time_idx % 16] = t;
+                            m_tel_time_idx++;
+                            if (m_tel_time_idx >= 2) {
+                                int oldest = (m_tel_time_idx >= 16) ? m_tel_time_idx - 16 : 0;
+                                double dt = t - m_tel_times[oldest % 16];
+                                int count = m_tel_time_idx - oldest;
+                                if (dt > 0.001 && count > 1)
+                                    m_tel_rate.store((float)((count - 1) / dt));
+                            }
+                        }
+                    } else {
+                        m_tel_rejected.fetch_add(1);
+                    }
+                }
+            }
+        } else if (strcmp(es, "resp") == 0 || strcmp(es, "log") == 0) {
+            if (strcmp(es, "resp") == 0) m_cobs_resp.fetch_add(1); else m_cobs_log.fetch_add(1);
+            const cJSON* tx = cJSON_GetObjectItem(root, "text");
+            if (tx && cJSON_IsString(tx) && tx->valuestring[0]) {
+                std::lock_guard<std::mutex> lk(m_line_mutex);
+                m_line_queue.emplace_back(tx->valuestring);
+            }
+        }
+    } else if (strcmp(ts, "resp") == 0) {
+        // Direct reply to one of our verbs. `status` replies carry the full body.
+        const cJSON* verb = cJSON_GetObjectItem(root, "verb");
+        const char* vs = (verb && cJSON_IsString(verb)) ? verb->valuestring : "";
+        if (strcmp(vs, "status") == 0) parseStatusBody(root);
+        // list_files results (Phase 3) may carry a "files" array — parse if present.
+        const cJSON* files = cJSON_GetObjectItem(root, "files");
+        if (files && cJSON_IsArray(files)) {
+            std::lock_guard<std::mutex> lk(m_status_mutex);
+            m_files.clear();
+            cJSON* it = nullptr;
+            cJSON_ArrayForEach(it, files) {
+                if (cJSON_IsString(it)) m_files.emplace_back(it->valuestring);
+                else { cJSON* nm = cJSON_GetObjectItem(it, "name");
+                       if (nm && cJSON_IsString(nm)) m_files.emplace_back(nm->valuestring); }
+            }
+        }
+    }
+    // "hello" → nothing to do (auth disabled on the LAN by default).
+
+    cJSON_Delete(root);
+}
+
+void UdpTransport::parseStatusBody(void* cjson_obj) {
+    cJSON* o = (cJSON*)cjson_obj;
+    auto getstr = [&](const char* k) -> const char* {
+        cJSON* v = cJSON_GetObjectItem(o, k);
+        return (v && cJSON_IsString(v)) ? v->valuestring : nullptr;
+    };
+    std::lock_guard<std::mutex> lk(m_status_mutex);
+    if (const char* s = getstr("source"))        m_source = s;
+    if (const char* s = getstr("boot_source"))   m_boot_source = s;
+    if (const char* s = getstr("play_state"))    m_play_state = s;
+    cJSON* demo = cJSON_GetObjectItem(o, "selected_demo");
+    if (demo) m_selected_demo = cJSON_IsString(demo) ? demo->valuestring : "";
+    cJSON* mem = cJSON_GetObjectItem(o, "mem");
+    if (mem && cJSON_IsObject(mem)) {
+        cJSON* u = cJSON_GetObjectItem(mem, "used");
+        cJSON* f = cJSON_GetObjectItem(mem, "free");
+        if (u && cJSON_IsNumber(u)) m_mem_used.store((long)u->valuedouble);
+        if (f && cJSON_IsNumber(f)) m_mem_free.store((long)f->valuedouble);
+    }
+}
+
+// ── RX accessors ────────────────────────────────────────────────────
+std::vector<std::string> UdpTransport::drainLines() {
+    std::lock_guard<std::mutex> lk(m_line_mutex);
+    std::vector<std::string> out;
+    out.swap(m_line_queue);
+    return out;
+}
+
+ESP32Telemetry UdpTransport::getLatestTelemetry() const {
+    std::lock_guard<std::mutex> lk(m_tel_mutex);
+    return m_telemetry;
+}
+
+std::string UdpTransport::source() const {
+    std::lock_guard<std::mutex> lk(m_status_mutex); return m_source;
+}
+std::string UdpTransport::bootSource() const {
+    std::lock_guard<std::mutex> lk(m_status_mutex); return m_boot_source;
+}
+std::string UdpTransport::playState() const {
+    std::lock_guard<std::mutex> lk(m_status_mutex); return m_play_state;
+}
+std::string UdpTransport::selectedDemo() const {
+    std::lock_guard<std::mutex> lk(m_status_mutex); return m_selected_demo;
+}
+std::vector<std::string> UdpTransport::deviceFiles() const {
+    std::lock_guard<std::mutex> lk(m_status_mutex); return m_files;
+}

--- a/app/src/udp_transport.h
+++ b/app/src/udp_transport.h
@@ -1,0 +1,133 @@
+#pragma once
+/*
+ * UdpTransport — network HIL transport to the Voron bridge.
+ *
+ *   Motion plane : UDP datagrams, one verbatim COBS frame per datagram
+ *                  (CH_DATA18 baked OR CH_DATA_RAW float32 — same bytes the
+ *                  serial path would WriteFile()). Fire-and-forget.
+ *   Control plane: a line-JSON TCP client to the bridge (default :8789),
+ *                  reusing the winsock + cJSON style of control_server.cpp.
+ *                  Carries set_source / play / demo-file verbs and receives
+ *                  status / telemetry / resp / log events.
+ *
+ * Implements the full ITransport superset so the existing HIL device-card UI
+ * and pipeline code drive it unchanged. Serial-specific COBS decode counters
+ * map to bridge-relayed frame counts where meaningful, else 0.
+ *
+ * WSAStartup is owned by App() — this class does not init/teardown winsock.
+ */
+
+#include "transport.h"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <string>
+#include <vector>
+
+class UdpTransport : public ITransport {
+public:
+    // host: bridge address (IP or hostname). udp_port: motion. tcp_port: control.
+    UdpTransport(const char* host, int udp_port, int tcp_port);
+    ~UdpTransport() override;
+
+    // ── ITransport ───────────────────────────────────────────────────
+    bool isOpen() const override { return m_open.load(); }
+    void close() override;
+
+    bool write(const uint8_t* data, int len) override;   // raw UDP datagram
+    bool sendCommand(const char* cmd) override;          // UDP COBS CH_CMD (fwd-compat)
+    bool sendCobsData(const uint32_t raw[6], int bit_depth) override;  // baked 0x06
+    bool sendCobsDataRaw(const float raw[6]) override;                 // raw   0x07
+    bool sendCobsCommand(const char* cmd) override;
+
+    std::vector<std::string> drainLines() override;
+    ESP32Telemetry getLatestTelemetry() const override;
+
+    const char* portName() const override { return m_name; }
+    int   rxBytes() const override { return m_rx_bytes.load(); }
+    int   txBytes() const override { return m_tx_bytes.load(); }
+    int   telemetrySeq() const override { return m_tel_seq.load(); }
+    float telemetryRate() const override { return m_tel_rate.load(); }
+    int   telemetryRejected() const override { return m_tel_rejected.load(); }
+
+    void setCobsMode(bool v) override { m_cobs_mode = v; }
+    bool isCobsMode() const  override { return m_cobs_mode; }
+    int  cobsDelimiters() const override { return 0; }   // bridge frames upstream
+    int  cobsDecodeOk()   const override { return m_ctrl_msgs.load(); }
+    int  cobsDecodeFail() const override { return 0; }
+    int  cobsTel()  const override { return m_cobs_tel.load(); }
+    int  cobsResp() const override { return m_cobs_resp.load(); }
+    int  cobsLog()  const override { return m_cobs_log.load(); }
+
+    Kind kind() const override { return Kind::Network; }
+
+    // ── Network-specific control surface (used by the HIL device card) ──
+    bool controlConnected() const { return m_ctrl_connected.load(); }
+    // Send a raw line-JSON request to the bridge control plane. Returns false
+    // if the control channel is down. `\n` is appended by the transport.
+    bool controlSend(const std::string& json_line);
+
+    // Snapshot of the last bridge status body (thread-safe copies).
+    std::string source() const;          // "OFF" | "DEMO" | "LIVE" | ""
+    std::string bootSource() const;
+    std::string playState() const;
+    std::string selectedDemo() const;
+    long memUsed() const { return m_mem_used.load(); }   // -1 = unknown
+    long memFree() const { return m_mem_free.load(); }   // -1 = unknown
+    std::vector<std::string> deviceFiles() const;        // on-device demo files
+
+private:
+    void ctrlReaderThread();
+    void handleControlLine(const char* line);
+    void parseStatusBody(void* cjson_obj);   // void* = cJSON* (avoid header leak)
+
+    char m_name[64] = {};
+    std::string m_host;
+    int m_udp_port = 0;
+    int m_tcp_port = 0;
+
+    std::atomic<bool> m_open{false};
+    bool m_cobs_mode = true;
+
+    // UDP motion socket
+    uintptr_t m_udp_sock = ~(uintptr_t)0;   // SOCKET; INVALID_SOCKET sentinel
+    struct sockaddr_storage* m_udp_addr = nullptr;
+    int m_udp_addr_len = 0;
+    std::mutex m_udp_mutex;
+
+    // TCP control socket + reader
+    std::atomic<uintptr_t> m_ctrl_sock{~(uintptr_t)0};
+    std::thread m_ctrl_reader;
+    std::atomic<bool> m_ctrl_stop{false};
+    std::atomic<bool> m_ctrl_connected{false};
+    std::mutex m_ctrl_send_mutex;
+
+    // Counters
+    std::atomic<int> m_tx_bytes{0};
+    std::atomic<int> m_rx_bytes{0};
+    std::atomic<int> m_ctrl_msgs{0};
+    std::atomic<int> m_cobs_tel{0};
+    std::atomic<int> m_cobs_resp{0};
+    std::atomic<int> m_cobs_log{0};
+
+    // Telemetry (relayed from bridge CH_TEL events)
+    mutable std::mutex m_tel_mutex;
+    ESP32Telemetry m_telemetry = {};
+    std::atomic<int>   m_tel_seq{0};
+    std::atomic<float> m_tel_rate{0.0f};
+    std::atomic<int>   m_tel_rejected{0};
+    double m_tel_times[16] = {};
+    int    m_tel_time_idx = 0;
+
+    // Line queue (resp/log text → app handleHilLine)
+    std::mutex m_line_mutex;
+    std::vector<std::string> m_line_queue;
+
+    // Bridge status snapshot
+    mutable std::mutex m_status_mutex;
+    std::string m_source, m_boot_source, m_play_state, m_selected_demo;
+    std::atomic<long> m_mem_used{-1};
+    std::atomic<long> m_mem_free{-1};
+    std::vector<std::string> m_files;
+};

--- a/app/src/ui_panels.cpp
+++ b/app/src/ui_panels.cpp
@@ -1,5 +1,6 @@
 #include "ui_panels.h"
 #include "serial_port.h"
+#include "udp_transport.h"
 #include "platform_viz.h"
 #include "test_harness_panel.h"
 #include "cJSON.h"
@@ -28,6 +29,152 @@ namespace fs = std::filesystem;
 
 static ImVec4 ColorFromFloat4(const float c[4]) {
     return ImVec4(c[0], c[1], c[2], c[3]);
+}
+
+// ── Network HIL bridge panel (source selector + demo files) ─────────
+// Rendered inside the HIL device card for Network connections only. Drives the
+// bridge line-JSON TCP control plane (set_source / play / list_files / mem /
+// select_demo / upload_file / delete_file). See bridge/PROTOCOL.md.
+static void DrawHilBridgePanel(Entity& e) {
+    UdpTransport* ut = (e.serial && e.serial->kind() == ITransport::Kind::Network)
+                       ? static_cast<UdpTransport*>(e.serial.get()) : nullptr;
+    if (!ut) return;
+
+    ImGui::Separator();
+    ImGui::Text("Bridge Control");
+    bool ctrl = ut->controlConnected();
+    if (ctrl) ImGui::TextColored(ImVec4(0.2f, 0.83f, 0.6f, 1.0f), "Control link: connected");
+    else      ImGui::TextColored(ImVec4(0.98f, 0.6f, 0.2f, 1.0f), "Control link: offline (motion UDP still streams)");
+
+    // Helper: send a verb+field JSON line over the control plane.
+    auto send_verb = [&](const char* verb, const char* field, const char* val) {
+        cJSON* r = cJSON_CreateObject();
+        cJSON_AddStringToObject(r, "verb", verb);
+        if (field && val) cJSON_AddStringToObject(r, field, val);
+        char* s = cJSON_PrintUnformatted(r);
+        if (s) { ut->controlSend(s); cJSON_free(s); }
+        cJSON_Delete(r);
+    };
+
+    // ── Source selector: OFF / DEMO / LIVE ──
+    std::string src = ut->source();
+    ImGui::Spacing();
+    ImGui::Text("Source:");
+    ImGui::SameLine();
+    struct SrcBtn { const char* label; const char* val; ImVec4 col; };
+    const SrcBtn btns[3] = {
+        { "OFF",  "OFF",  ImVec4(0.75f, 0.25f, 0.25f, 1.0f) },
+        { "DEMO", "DEMO", ImVec4(0.25f, 0.45f, 0.75f, 1.0f) },
+        { "LIVE", "LIVE", ImVec4(0.20f, 0.65f, 0.40f, 1.0f) },
+    };
+    for (int i = 0; i < 3; i++) {
+        bool active = (src == btns[i].val);
+        if (active) {
+            ImGui::PushStyleColor(ImGuiCol_Button, btns[i].col);
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, btns[i].col);
+        }
+        if (ImGui::Button(btns[i].label, ImVec2(70, 30))) {
+            send_verb("set_source", "source", btns[i].val);
+        }
+        if (active) ImGui::PopStyleColor(2);
+        if (i < 2) ImGui::SameLine();
+    }
+    ImGui::TextDisabled("Current: %s   Play: %s",
+        src.empty() ? "?" : src.c_str(),
+        ut->playState().empty() ? "?" : ut->playState().c_str());
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("OFF homes the platform (kill motion). DEMO plays the\n"
+            "selected on-device .m6p. LIVE opens the UDP motion gate.");
+
+    // Play transport (DEMO)
+    if (ImGui::SmallButton("Play")) send_verb("play", "action", "start");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Stop")) send_verb("play", "action", "stop");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Loop")) send_verb("play", "action", "loop");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Refresh##bridgestatus")) send_verb("status", nullptr, nullptr);
+
+    // ── Demo file panel ──
+    ImGui::Spacing();
+    ImGui::Text("Device Demos");
+    if (ImGui::SmallButton("List##files")) send_verb("list_files", nullptr, nullptr);
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Mem##files")) send_verb("mem", nullptr, nullptr);
+    long used = ut->memUsed(), freeb = ut->memFree();
+    if (used >= 0 || freeb >= 0) {
+        ImGui::SameLine();
+        ImGui::TextDisabled("used=%ld  free=%ld", used, freeb);
+    }
+
+    std::string sel = ut->selectedDemo();
+    std::vector<std::string> files = ut->deviceFiles();
+    if (files.empty()) {
+        ImGui::TextDisabled("(no files listed — press List; Phase-3 firmware returns them)");
+    } else {
+        if (ImGui::BeginListBox("##demofiles", ImVec2(-1, 96))) {
+            for (const auto& f : files) {
+                bool is_sel = (f == sel);
+                if (ImGui::Selectable(f.c_str(), is_sel))
+                    send_verb("select_demo", "name", f.c_str());
+                if (is_sel) {
+                    ImGui::SameLine();
+                    ImGui::TextColored(ImVec4(0.2f, 0.83f, 0.6f, 1.0f), "(selected)");
+                }
+            }
+            ImGui::EndListBox();
+        }
+    }
+
+    // Burn (upload) + delete. Upload is the chunked-handshake shape; the bridge
+    // upload_file is a STUB today (real erase+stream+CRC is Phase-3 firmware).
+    static char s_burn_path[260] = "sequence.m6p";
+    ImGui::SetNextItemWidth(-90);
+    ImGui::InputText("##burnpath", s_burn_path, sizeof(s_burn_path));
+    ImGui::SameLine();
+    if (ImGui::Button("Burn", ImVec2(80, 0))) {
+        // Read the local .m6p and send as a single-chunk upload_file (base64).
+        FILE* f = fopen(s_burn_path, "rb");
+        if (f) {
+            fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
+            std::vector<unsigned char> buf((size_t)(sz > 0 ? sz : 0));
+            size_t rd = (sz > 0) ? fread(buf.data(), 1, (size_t)sz, f) : 0;
+            fclose(f);
+            static const char* B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            std::string b64;
+            for (size_t i = 0; i < rd; i += 3) {
+                unsigned n = buf[i] << 16;
+                if (i + 1 < rd) n |= buf[i + 1] << 8;
+                if (i + 2 < rd) n |= buf[i + 2];
+                b64.push_back(B64[(n >> 18) & 63]);
+                b64.push_back(B64[(n >> 12) & 63]);
+                b64.push_back((i + 1 < rd) ? B64[(n >> 6) & 63] : '=');
+                b64.push_back((i + 2 < rd) ? B64[n & 63] : '=');
+            }
+            const char* base = strrchr(s_burn_path, '/');
+            const char* base2 = strrchr(s_burn_path, '\\');
+            const char* name = base2 ? base2 + 1 : (base ? base + 1 : s_burn_path);
+            cJSON* r = cJSON_CreateObject();
+            cJSON_AddStringToObject(r, "verb", "upload_file");
+            cJSON_AddStringToObject(r, "name", name);
+            cJSON_AddNumberToObject(r, "chunk_index", 0);
+            cJSON_AddNumberToObject(r, "total_chunks", 1);
+            cJSON_AddStringToObject(r, "data", b64.c_str());
+            char* s = cJSON_PrintUnformatted(r);
+            if (s) { ut->controlSend(s); cJSON_free(s); }
+            cJSON_Delete(r);
+            g_app.log(e.id, "hil", "Burn: uploading %s (%ld bytes) to bridge", name, sz);
+        } else {
+            g_app.log(e.id, "hil", "Burn failed: cannot open %s", s_burn_path);
+        }
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Upload a local .m6p to the device via the bridge.\n"
+            "Export one first with the control API 'export_sequence'.");
+    if (!sel.empty()) {
+        ImGui::SameLine();
+        if (ImGui::Button("Delete selected")) send_verb("delete_file", "name", sel.c_str());
+    }
 }
 
 // ── Workspace Save / Load ───────────────────────────────────────────
@@ -2556,21 +2703,39 @@ static void DrawEntitySettingsContent(Entity& e) {
             ImGui::Text("ESP32 Connection");
 
             bool connected = e.serial && e.serial->isOpen();
+            bool is_net = e.serial ? (e.serial->kind() == ITransport::Kind::Network) : e.hil_network;
+
+            // ── Transport kind selector (locked while connected) ──
+            if (!connected) {
+                int kind_idx = e.hil_network ? 1 : 0;
+                const char* kinds[] = { "Serial (USB)", "Network (Voron bridge)" };
+                ImGui::SetNextItemWidth(220);
+                if (ImGui::Combo("Transport##hilkind", &kind_idx, kinds, 2)) {
+                    e.hil_network = (kind_idx == 1);
+                    g_app.settings_dirty = true;
+                }
+                if (ImGui::IsItemHovered()) {
+                    ImGui::SetTooltip("Serial: direct USB COBS to the ESP32.\n"
+                        "Network: UDP motion + line-JSON TCP control to the\n"
+                        "Voron HIL bridge, which relays to the mini over USB.");
+                }
+            }
 
             if (connected) {
                 // ── Connected state ──
-                ImGui::TextColored(ImVec4(0.2f, 0.83f, 0.6f, 1.0f), "Connected: %s", e.serial->portName());
+                ImGui::TextColored(ImVec4(0.2f, 0.83f, 0.6f, 1.0f), "Connected: %s%s",
+                    is_net ? "net " : "", e.serial->portName());
                 ImGui::Text("RX: %d bytes  TX: %d bytes", e.serial->rxBytes(), e.serial->txBytes());
                 int rej = e.serial ? e.serial->telemetryRejected() : 0;
                 ImGui::Text("Telemetry: %.0f Hz (seq %d)", e.rate_tel_hz, e.hil_tel_seq);
                 if (e.serial) {
                     ImGui::Text("COBS: delim=%d ok=%d fail=%d tel=%d resp=%d log=%d",
-                        e.serial->m_cobs_delimiters.load(),
-                        e.serial->m_cobs_decode_ok.load(),
-                        e.serial->m_cobs_decode_fail.load(),
-                        e.serial->m_cobs_tel.load(),
-                        e.serial->m_cobs_resp.load(),
-                        e.serial->m_cobs_log.load());
+                        e.serial->cobsDelimiters(),
+                        e.serial->cobsDecodeOk(),
+                        e.serial->cobsDecodeFail(),
+                        e.serial->cobsTel(),
+                        e.serial->cobsResp(),
+                        e.serial->cobsLog());
                 }
                 if (rej > 0) {
                     ImGui::SameLine();
@@ -2594,26 +2759,109 @@ static void DrawEntitySettingsContent(Entity& e) {
                     e.serial->close();
                     e.serial.reset();
                     e.transport.usb_connected = false;
+                    e.transport.udp_connected = false;
                     e.hil_auto_connect = false;  // manual disconnect disables auto-reconnect
+                    if (is_net) {
+                        // Network handshake is app-forced; clear it so motion re-gates
+                        // until the next Connect.
+                        e.hil_handshake_ok = false;
+                        e.hil_handshake_phase = HandshakePhase::Idle;
+                    }
                 }
                 ImGui::PopStyleColor(2);
 
-                ImGui::Checkbox("Auto-reconnect", &e.hil_auto_connect);
-                if (ImGui::IsItemHovered()) {
-                    ImGui::SetTooltip("Automatically reconnect if the connection is lost.\n"
-                        "Retries every 3 seconds.");
+                if (!is_net) {
+                    ImGui::Checkbox("Auto-reconnect", &e.hil_auto_connect);
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::SetTooltip("Automatically reconnect if the connection is lost.\n"
+                            "Retries every 3 seconds.");
+                    }
                 }
 
-                // Query buttons
-                if (ImGui::SmallButton("VERSION?")) { e.serial->sendCommand("VERSION?"); }
+                // ── Raw-HIL streaming toggle (capability-gated) ──
+                if (e.hil_cap_raw) {
+                    if (ImGui::Checkbox("Stream RAW (ESP cues)##rawmode", &e.hil_raw_mode))
+                        g_app.settings_dirty = true;
+                    if (ImGui::IsItemHovered()) {
+                        ImGui::SetTooltip("RAW: stream pre-cueing telemetry (6x float32, CH_DATA_RAW 0x07);\n"
+                            "the ESP runs the single on-device cue engine (one feel demo+live).\n"
+                            "Off: baked motion (post-cueing 6x uint24, CH_DATA18 0x06).");
+                    }
+                } else {
+                    ImGui::TextDisabled("RAW streaming: device does not advertise raw-HIL");
+                }
+
+                if (!is_net) {
+                    // Query buttons (serial control channel)
+                    if (ImGui::SmallButton("VERSION?")) { e.serial->sendCommand("VERSION?"); }
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("CONFIG?")) { e.serial->sendCommand("CONFIG?"); }
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("SCALE?")) { e.serial->sendCommand("SCALE?"); }
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("BITS?")) { e.serial->sendCommand("BITS?"); }
+                    ImGui::SameLine();
+                    if (ImGui::SmallButton("FINGERPRINT?")) { e.serial->sendCommand("FINGERPRINT?"); }
+                } else {
+                    // ── Network source selector + demo panel (bridge TCP-JSON) ──
+                    DrawHilBridgePanel(e);
+                }
+            } else if (e.hil_network) {
+                // ── Disconnected: Network bridge connect UI ──
+                ImGui::TextDisabled("Not connected (network)");
+                ImGui::TextWrapped("Connect to the Voron HIL bridge. Motion streams over "
+                    "UDP; source / demo control uses the line-JSON TCP port.");
+
+                ImGui::SetNextItemWidth(200);
+                if (ImGui::InputText("Bridge host##nethost", e.hil_host, sizeof(e.hil_host)))
+                    g_app.settings_dirty = true;
+                ImGui::SetNextItemWidth(110);
+                if (ImGui::InputInt("UDP port##netudp", &e.hil_udp_port, 0)) {
+                    if (e.hil_udp_port < 1) e.hil_udp_port = 1;
+                    if (e.hil_udp_port > 65535) e.hil_udp_port = 65535;
+                    g_app.settings_dirty = true;
+                }
                 ImGui::SameLine();
-                if (ImGui::SmallButton("CONFIG?")) { e.serial->sendCommand("CONFIG?"); }
-                ImGui::SameLine();
-                if (ImGui::SmallButton("SCALE?")) { e.serial->sendCommand("SCALE?"); }
-                ImGui::SameLine();
-                if (ImGui::SmallButton("BITS?")) { e.serial->sendCommand("BITS?"); }
-                ImGui::SameLine();
-                if (ImGui::SmallButton("FINGERPRINT?")) { e.serial->sendCommand("FINGERPRINT?"); }
+                ImGui::SetNextItemWidth(110);
+                if (ImGui::InputInt("TCP port##nettcp", &e.hil_tcp_port, 0)) {
+                    if (e.hil_tcp_port < 1) e.hil_tcp_port = 1;
+                    if (e.hil_tcp_port > 65535) e.hil_tcp_port = 65535;
+                    g_app.settings_dirty = true;
+                }
+
+                ImGui::SliderInt("TX Rate (Hz)##nc", &e.hil_tx_hz, 10, 1000);
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("Motion datagram rate to the bridge.");
+
+                ImGui::Spacing();
+                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.45f, 0.7f, 1.0f));
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.55f, 0.85f, 1.0f));
+                if (ImGui::Button("Connect (Network)", ImVec2(-1, 28))) {
+                    auto up = std::make_shared<UdpTransport>(e.hil_host, e.hil_udp_port, e.hil_tcp_port);
+                    up->setCobsMode(true);
+                    e.serial = up;
+                    e.hil_network = true;
+                    e.transport.udp_connected = true;
+                    snprintf(e.transport.udp_ip, sizeof(e.transport.udp_ip), "%s", e.hil_host);
+                    // The bridge/ESP own device identity + cueing; the app streams
+                    // raw and drives source over TCP. Bypass the serial FINGERPRINT
+                    // handshake and enable motion. Network = the raw-HIL path.
+                    e.hil_tel_seq = 0;
+                    e.hil_cap_raw = true;
+                    e.hil_raw_mode = true;
+                    e.hil_handshake_ok = true;
+                    e.hil_handshake_pending = false;
+                    e.hil_handshake_phase = HandshakePhase::Ready;
+                    e.hil_last_error[0] = '\0';
+                    snprintf(e.hil_handshake_msg, sizeof(e.hil_handshake_msg),
+                             up->controlConnected() ? "Bridge connected"
+                                                    : "Motion UDP up (control offline)");
+                    g_app.log(e.id, "hil", "Network HIL: UDP %s:%d, control %s:%d (%s)",
+                              e.hil_host, e.hil_udp_port, e.hil_host, e.hil_tcp_port,
+                              up->controlConnected() ? "connected" : "control unreachable");
+                    g_app.settings_dirty = true;
+                }
+                ImGui::PopStyleColor(2);
             } else {
                 // ── Disconnected state — COM port selector ──
                 if (e.hil_auto_connect && e.hil_port[0] != '\0') {


### PR DESCRIPTION
App-side of the HIL network bridge (HIL_BRIDGE.md **Phase 2**; DECISIONS rounds **3 + 4**). The app can now drive the ESP32 "mini" over the Voron bridge (UDP motion + line-JSON TCP control) alongside direct USB serial, and can stream **pre-cueing RAW telemetry** so the single on-device cue engine owns the feel for demo and live.

## What's in it
**Transport abstraction**
- New `app/src/transport.h`: `ITransport` — a ~16-method **superset** interface (the HIL device card reads SerialPort-specific stats), `kind() {Serial,Network}`, moved `ESP32Telemetry`, and `sendCobsDataRaw()`.
- `SerialPort : public ITransport` (all methods `override`). The six COBS decode counters move from public atomics → **private + `cobs*()` accessors**; the one reader in `ui_panels.cpp` updated.
- `Entity::serial` → `shared_ptr<ITransport>`. `test_harness_panel`'s own dev-serial stays a concrete `SerialPort` (separate tool — not migrated).

**New COBS raw channel**
- `cobs.h`: `COBS_CH_DATA_RAW = 0x07` (6×float32 LE, pre-cueing, app axis order surge=0/sway=1). Baked `0x06` (uint24, with swap) unchanged.

**`UdpTransport` (`app/src/udp_transport.{h,cpp}`)**
- Same COBS frames as `serial_port.cpp`, emitted via winsock `sendto()` (one datagram = one frame), baked `0x06` or raw `0x07`.
- Opens the bridge line-JSON TCP control port (default **8789**), reusing the `control_server.cpp` winsock+cJSON pattern (no WebSocket dep). Decodes bridge `status`/`telemetry`/`resp`/`log` events → `getLatestTelemetry()`/`drainLines()`, so the existing app pipeline drives it unchanged.

**Raw-HIL, capability-gated**
- FINGERPRINT handler parses `caps=raw` / `rawhil=1` → `Entity::hil_cap_raw`. When `hil_cap_raw && hil_raw_mode`, `hilTxLoop` TX's `input_pct` (pre-cueing, app order, no swap) as float32 on `0x07`; else baked path unchanged. Old firmware omits the flag → baked. Network connect implies the raw path.

**Connection + source/demo UI (`ui_panels.cpp`)**
- Serial|Network selector + host / UDP / TCP fields; Network Connect builds `UdpTransport` + TCP control client and bypasses the serial FINGERPRINT handshake (bridge/ESP own identity + cueing). Serial path unchanged.
- OFF/DEMO/LIVE source selector + play + demo panel (`list_files`/`mem`/`select_demo`/`upload_file`[Burn]/`delete`) inside the HIL card, **Network-only**, driving the bridge TCP-JSON verbs. New fields persisted in settings.

**`.m6p` raw export (change-list a)**
- `control_server.cpp` `export_sequence` gains `raw=1` → **M6P2** header + 6×float32 LE pre-cueing samples (no swap); baked M6P1 export unchanged.

## Build-verify (espressif cmake 3.30.2 / VS2022)
- Unit tests: **47/47 pass**.
- SIL app (`app/`): configures, compiles, **links clean** (FetchContent glfw/imgui/implot/cJSON).
- No hardware run; not merged.

## Open questions
See PR discussion / agent summary — notably network-path handshake semantics, `caps=raw` firmware token spelling, and Burn/upload being a bridge STUB until Phase-3 firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)